### PR TITLE
When calendar feed for id was not found, it caused mediatype exceptio…

### DIFF
--- a/app/src/main/java/fi/helsinki/opintoni/exception/GlobalExceptionHandlers.java
+++ b/app/src/main/java/fi/helsinki/opintoni/exception/GlobalExceptionHandlers.java
@@ -18,6 +18,7 @@
 package fi.helsinki.opintoni.exception;
 
 import fi.helsinki.opintoni.exception.http.BadRequestException;
+import fi.helsinki.opintoni.exception.http.CalendarFeedNotFoundException;
 import fi.helsinki.opintoni.exception.http.ForbiddenException;
 import fi.helsinki.opintoni.exception.http.NotFoundException;
 import org.slf4j.Logger;
@@ -67,6 +68,11 @@ public class GlobalExceptionHandlers extends ResponseEntityExceptionHandler {
         LOGGER.error("Caught exception", e);
 
         return new ResponseEntity<>(new CommonError("Something went wrong"), HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(value = CalendarFeedNotFoundException.class)
+    public ResponseEntity handleCalendarFeedNotFound() throws Exception {
+        return new ResponseEntity(HttpStatus.NOT_FOUND);
     }
 
     @Override

--- a/app/src/main/java/fi/helsinki/opintoni/exception/http/CalendarFeedNotFoundException.java
+++ b/app/src/main/java/fi/helsinki/opintoni/exception/http/CalendarFeedNotFoundException.java
@@ -1,0 +1,25 @@
+/*
+ * This file is part of MystudiesMyteaching application.
+ *
+ * MystudiesMyteaching application is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MystudiesMyteaching application is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MystudiesMyteaching application.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package fi.helsinki.opintoni.exception.http;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.NOT_FOUND)
+public class CalendarFeedNotFoundException extends RuntimeException {
+}

--- a/app/src/main/java/fi/helsinki/opintoni/service/CalendarService.java
+++ b/app/src/main/java/fi/helsinki/opintoni/service/CalendarService.java
@@ -81,7 +81,7 @@ public class CalendarService {
     public String showCalendarFeed(String feedId, Locale locale) {
         return calendarTransactionalService.findByFeedId(feedId)
             .map(c -> getCalendarFeedFromEvents(c, locale))
-            .orElseThrow(() -> new CalendarFeedNotFoundException());
+            .orElseThrow(CalendarFeedNotFoundException::new);
     }
 
     private String getCalendarFeedFromEvents(CalendarFeed calendarFeed, Locale locale) {

--- a/app/src/main/java/fi/helsinki/opintoni/service/CalendarService.java
+++ b/app/src/main/java/fi/helsinki/opintoni/service/CalendarService.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Lists;
 import fi.helsinki.opintoni.domain.CalendarFeed;
 import fi.helsinki.opintoni.dto.CalendarFeedDto;
 import fi.helsinki.opintoni.dto.EventDto;
+import fi.helsinki.opintoni.exception.http.CalendarFeedNotFoundException;
 import fi.helsinki.opintoni.integration.DateFormatter;
 import fi.helsinki.opintoni.integration.oodi.OodiClient;
 import fi.helsinki.opintoni.integration.oodi.OodiRoles;
@@ -41,8 +42,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
-
-import static fi.helsinki.opintoni.exception.http.NotFoundException.notFoundException;
 
 @Service
 public class CalendarService {
@@ -82,7 +81,7 @@ public class CalendarService {
     public String showCalendarFeed(String feedId, Locale locale) {
         return calendarTransactionalService.findByFeedId(feedId)
             .map(c -> getCalendarFeedFromEvents(c, locale))
-            .orElseThrow(notFoundException("Calendar feed not found"));
+            .orElseThrow(() -> new CalendarFeedNotFoundException());
     }
 
     private String getCalendarFeedFromEvents(CalendarFeed calendarFeed, Locale locale) {


### PR DESCRIPTION
…n because exception was in json format. Now calendar feed uses it's own 404 exception type and handler