### PR TITLE
This should keep session alive for 1h if app is inactive

### DIFF
--- a/app/src/main/resources/config/application.yml
+++ b/app/src/main/resources/config/application.yml
@@ -4,6 +4,7 @@ server:
         timeout: 1800 # Seconds
         cookie:
             http-only: true
+            max-age: 3600
             path: /
             domain: helsinki.fi
 

--- a/app/src/main/resources/config/application.yml
+++ b/app/src/main/resources/config/application.yml
@@ -1,10 +1,10 @@
 server:
     port: 8080
     session:
-        timeout: 1800 # Seconds
+        timeout: 3600 # Seconds
         cookie:
             http-only: true
-            max-age: 3600
+            max-age: 86400
             path: /
             domain: helsinki.fi
 


### PR DESCRIPTION
Webviewin sisällä toimivan opintukseni pitäisi nyt säilyttää kirjautuminen tunnin ajan, vaikka viewin sulkisi välillä. Tätä pääsee kokeilemaan kunnolla (mobiililla) vasta dev- tai QA-ympäristössä ja sitten nähdään riittääkö tunti vai tarvitaanko vuorokausia.