### PR TITLE
OO-1105 "Optime-lisätietojen näkymän muokkaus Opintoni kalenteriin" a…

### DIFF
--- a/app/src/main/java/fi/helsinki/opintoni/dto/EventDto.java
+++ b/app/src/main/java/fi/helsinki/opintoni/dto/EventDto.java
@@ -17,7 +17,6 @@
 
 package fi.helsinki.opintoni.dto;
 
-import com.google.common.collect.Lists;
 import fi.helsinki.opintoni.dto.portfolio.CourseMaterialDto;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
@@ -123,17 +122,14 @@ public class EventDto implements Comparable<EventDto> {
             .collect(Collectors.joining(", "));
     }
 
-    private String getOodiEventTitle() {
-        return Lists.newArrayList(title, optimeExtras).stream()
-            .filter(Objects::nonNull)
-            .map(Object::toString)
-            .collect(Collectors.joining(", "));
+    public String getOptimeExtrasAsString() {
+        return optimeExtras == null ?
+                "" :
+                optimeExtras.toString();
     }
 
     public String getFullEventTitle() {
-        return Source.OODI.equals(source)
-            ? getOodiEventTitle()
-            : String.format("%s, %s", title, courseTitle);
+        return Source.OODI.equals(source) ? title : String.format("%s, %s", title, courseTitle);
     }
 
 }

--- a/app/src/main/java/fi/helsinki/opintoni/dto/OptimeExtrasDto.java
+++ b/app/src/main/java/fi/helsinki/opintoni/dto/OptimeExtrasDto.java
@@ -22,12 +22,12 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class OptimeExtrasDto {
-    
+
     public String otherNotes;
 
     public String roomNotes;
 
-    public String staffNotes; 
+    public String staffNotes;
 
     public OptimeExtrasDto(String otherNotes, String roomNotes, String staffNotes) {
         this.otherNotes = otherNotes;
@@ -37,9 +37,9 @@ public class OptimeExtrasDto {
 
     @Override
     public String toString() {
-        return Lists.newArrayList(otherNotes, roomNotes, staffNotes)
+        return Lists.newArrayList(roomNotes, staffNotes, otherNotes)
             .stream()
             .filter(Objects::nonNull)
-            .collect(Collectors.joining(" "));
+            .collect(Collectors.joining(", "));
     }
 }

--- a/app/src/main/java/fi/helsinki/opintoni/service/CalendarService.java
+++ b/app/src/main/java/fi/helsinki/opintoni/service/CalendarService.java
@@ -114,6 +114,9 @@ public class CalendarService {
         eventProperties.add(new DtStart(convertStartDateToCalDate(eventDto)));
         eventProperties.add(new DtEnd(convertEndDateToCalDate(eventDto)));
         eventProperties.add(new Summary(eventDto.getFullEventTitle()));
+        if (!eventDto.getOptimeExtrasAsString().isEmpty()) {
+            eventProperties.add(new Description(eventDto.getOptimeExtrasAsString()));
+        }
         eventProperties.add(new Location((eventDto.getLocationsAsString())));
         eventProperties.add(generateUid());
 

--- a/app/src/main/resources/sampledata/oodi/studentevents.json
+++ b/app/src/main/resources/sampledata/oodi/studentevents.json
@@ -3749,14 +3749,14 @@
             "automatic_enabled": "false",
             "automatic_end_date": null,
             "automatic_end_time": null,
-            "building_address1": null,
+            "building_address1": "Siltavuorenpenger 3",
             "building_address2": null,
-            "building_country": null,
-            "building_id": null,
-            "building_zipcode": null,
+            "building_country": "FI",
+            "building_id": "41",
+            "building_zipcode": "00170",
             "cancelled": "false",
             "course_id": 121261022,
-            "end_date": "2018-05-29T06:00:00.000Z",
+            "end_date": "2018-08-11T06:00:00.000Z",
             "event_duration": 60,
             "event_id": 121261026,
             "event_visible": "true",
@@ -3780,11 +3780,11 @@
                 }
             ],
             "realisation_type_code": 17,
-            "room_id": null,
-            "room_name": null,
-            "room_name_short": null,
+            "room_id": 82454477,
+            "room_name": "Athena, Siltavuorenpenger 3A, sali 168",
+            "room_name_short": "Athena, sali 168",
             "simple_type_code": 1,
-            "start_date": "2018-05-29T05:00:00.000Z",
+            "start_date": "2018-08-11T05:00:00.000Z",
             "weekday_code": 2
         },
         {
@@ -3799,15 +3799,15 @@
             "building_zipcode": null,
             "cancelled": "false",
             "course_id": 121261022,
-            "end_date": "2018-05-29T07:00:00.000Z",
+            "end_date": "2018-08-11T07:00:00.000Z",
             "event_duration": 60,
             "event_id": 121261028,
             "event_visible": "true",
             "hidden": "true",
             "learningopportunity_id": "OODI-FLOW",
             "optimeExtras": {
-                "otherNotes": "testauksessa mukana",
-                "roomNotes": null,
+                "otherNotes": "Jos Optimessa olisi todella pitkä selitys tässä kohtaa, esimerkiksi noin sataneljäkymmentä merkkiä, niin miltä se näyttäisi eri näkymissä?",
+                "roomNotes": "huone 5",
                 "staffNotes": "Jorma Hynninen"
             },
             "realisation_name": [
@@ -3827,7 +3827,7 @@
             "room_name": null,
             "room_name_short": null,
             "simple_type_code": 1,
-            "start_date": "2018-05-29T06:00:00.000Z",
+            "start_date": "2018-08-11T06:00:00.000Z",
             "weekday_code": 2
         },
         {

--- a/app/src/test/java/fi/helsinki/opintoni/web/rest/privateapi/EnrollmentResourceGetStudentEventsTest.java
+++ b/app/src/test/java/fi/helsinki/opintoni/web/rest/privateapi/EnrollmentResourceGetStudentEventsTest.java
@@ -111,16 +111,17 @@ public class EnrollmentResourceGetStudentEventsTest extends SpringTest {
             .andExpect(jsonPath("$[3].source").value(EventDto.Source.COURSE_PAGE.name()))
             .andExpect(jsonPath("$[3].type").value(EventDto.Type.DEFAULT.name()));
     }
-    
+
     @Test
     public void thatStudentEventsContainCorrectDataWhenDataIsOverlapping() throws Exception {
         expectEventsWithOverlap(LANG_CODE_FI);
         performGetStudentEvents(LANG_CODE_FI, null, EVENT_TITLE_FI)
             .andExpect(jsonPath("$").isArray())
             .andExpect(jsonPath("$", hasSize(2)))
-            .andExpect(jsonPath("$[0].fullEventTitle").value("Formuloi... Harjoitus II, testauksessa mukana Aku Ankka"));
+            .andExpect(jsonPath("$[0].fullEventTitle").value("Formuloi... Harjoitus II"))
+            .andExpect(jsonPath("$[0].optimeExtrasAsString").value("Aku Ankka, testauksessa mukana"));
     }
-    
+
     @Test
     public void thatStudentEventsAreReturnedInSwedish() throws Exception {
         expectEvents(LANG_CODE_SV);
@@ -170,7 +171,7 @@ public class EnrollmentResourceGetStudentEventsTest extends SpringTest {
             .and()
             .enrollments();
     }
-    
+
     private void expectEventsWithOverlap(String langCode) {
         defaultStudentRequestChain()
             .events()

--- a/app/src/test/java/fi/helsinki/opintoni/web/rest/publicapi/PublicCalendarFeedResourceTest.java
+++ b/app/src/test/java/fi/helsinki/opintoni/web/rest/publicapi/PublicCalendarFeedResourceTest.java
@@ -59,7 +59,8 @@ public class PublicCalendarFeedResourceTest extends SpringTest {
                 "BEGIN:VEVENT",
                 "DTSTART;TZID=Europe/Helsinki:20161219T141500",
                 "DTEND;TZID=Europe/Helsinki:20161219T154500",
-                "SUMMARY:Formulat... Harjoitus II (en)\\, testauksessa mukana Aku Ankka",
+                "SUMMARY:Formulat... Harjoitus II (en)",
+                "DESCRIPTION:Aku Ankka\\, testauksessa mukana",
                 "LOCATION:Päärakennus\\, sali 1\\, Viikinkaari 11\\, Päärakennus\\, "
                     + "sali 2\\, Viikinkaari 11\\, Päärakennus\\, sali 3\\, Viikinkaari 11",
                 "UID:"),
@@ -104,24 +105,25 @@ public class PublicCalendarFeedResourceTest extends SpringTest {
                     expectedFeedEnd,
                     expectedCalendarEvents)))));
     }
-    
+
     @Test
     public void thatCalendarFeedIsDisplayedWithOverlappingEventData() throws Exception {
         Language language = Language.EN;
 
         expectOverlapping(language);
-       
+
         List<String> expectedCalendarEvents = newArrayList(
             eventToString(
                 "BEGIN:VEVENT",
                 "DTSTART;TZID=Europe/Helsinki:20161219T141500",
                 "DTEND;TZID=Europe/Helsinki:20161219T154500",
-                "SUMMARY:Formulat... Harjoitus II (en)\\, testauksessa mukana Aku Ankka",
+                "SUMMARY:Formulat... Harjoitus II (en)",
+                "DESCRIPTION:Aku Ankka\\, testauksessa mukana",
                 "LOCATION:Päärakennus\\, sali 1\\, Viikinkaari 11\\, Päärakennus\\, "
                     + "sali 2\\, Viikinkaari 11\\, Päärakennus\\, sali 3\\, Viikinkaari 11\\, overlapping where data",
                 "UID:")
         );
-        
+
         mockMvc.perform(get(String.format("/api/public/v1/calendar/c9ea7949-577c-458c-a9d9-3c2a39269dd8/%s", language.getCode())))
             .andExpect(status().isOk())
             .andExpect(content().contentType(WebConstants.TEXT_CALENDAR_UTF8))
@@ -133,17 +135,17 @@ public class PublicCalendarFeedResourceTest extends SpringTest {
     }
 
     private List<Matcher<String>> contentMatchers(String expectedFeedStart, String expectedFeedEnd, List<String> expectedCalendarEvents) {
-       
+
         List<Matcher<String>> matchers = newArrayList();
 
         if (expectedFeedStart != null) {
             matchers.add(new StringStartsWith(expectedFeedStart));
         }
-        
+
         if (expectedFeedEnd != null) {
             matchers.add(new StringEndsWith(expectedFeedEnd));
         }
-        
+
         matchers.addAll(expectedCalendarEvents.stream()
             .map(StringContains::containsString)
             .collect(Collectors.toList()));


### PR DESCRIPTION
…nd OO-1106 "Opintoni kalenterin Optime-lisätiedot halutaan näyttää Outlookin kalenterin description-kentässä"

- EventDto.fullEventTitle now returns just the title, and Optime extra fields are now in fields optimeExtras and optimeExtrasAsString.
- iCalendar feed now contains Optime extra fields in the Description field.
- Event height is now hardcoded to 48 pixels in the Calendar month view.
- Calendar and List views now show Optime extra fields, in revised order, after title and location data. Separated from each other by commas, and from title/location by a newline.
- Modified local test data in order to see something relevant in the UI.