### PR TITLE
OO-1249 Virkailijalle ei muodostu Opetukseniin kurssisivulinkkiä

### DIFF
--- a/src/main/java/fi/helsinki/opintoni/integration/coursepage/CoursePageIntegrationException.java
+++ b/src/main/java/fi/helsinki/opintoni/integration/coursepage/CoursePageIntegrationException.java
@@ -21,4 +21,8 @@ public class CoursePageIntegrationException extends RuntimeException {
     public CoursePageIntegrationException(String message, Throwable cause) {
         super(message, cause);
     }
+
+    public CoursePageIntegrationException(String message) {
+        super(message);
+    }
 }

--- a/src/main/java/fi/helsinki/opintoni/integration/coursepage/CoursePageRestClient.java
+++ b/src/main/java/fi/helsinki/opintoni/integration/coursepage/CoursePageRestClient.java
@@ -39,7 +39,7 @@ public class CoursePageRestClient implements CoursePageClient {
     private static final Logger log = LoggerFactory.getLogger(CoursePageRestClient.class);
 
     // Course Pages server only returns max. 10 course implementation per call.
-    private static final int COURSE_IMPLEMENTATION_PATCH_SIZE = 10;
+    private static final int COURSE_IMPLEMENTATION_BATCH_SIZE = 10;
 
     public CoursePageRestClient(String baseUrl, String apiPath, RestTemplate restTemplate) {
         this.baseUrl = baseUrl;
@@ -104,7 +104,7 @@ public class CoursePageRestClient implements CoursePageClient {
 
     @Override
     public List<CoursePageCourseImplementation> getCoursePages(List<String> courseImplementationIds, Locale locale) {
-        return Lists.partition(courseImplementationIds, COURSE_IMPLEMENTATION_PATCH_SIZE).parallelStream()
+        return Lists.partition(courseImplementationIds, COURSE_IMPLEMENTATION_BATCH_SIZE).parallelStream()
             .map(idListPartition ->
                 getCoursePageData("/course_implementation/{courseImplementationIds}",
                     new ParameterizedTypeReference<List<CoursePageCourseImplementation>>() {

--- a/src/main/java/fi/helsinki/opintoni/integration/coursepage/CoursePageRestClient.java
+++ b/src/main/java/fi/helsinki/opintoni/integration/coursepage/CoursePageRestClient.java
@@ -38,11 +38,8 @@ public class CoursePageRestClient implements CoursePageClient {
 
     private static final Logger log = LoggerFactory.getLogger(CoursePageRestClient.class);
 
-    // Based on https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers
-    // practical max length of request uri is 2000 characters. Course implementation id is 9 numeric characters long,
-    // with comma separator 190 ids is going to take 1900 characters. Remaining 100 characters are left as space
-    // for course page url
-    private static final int COURSE_IMPLEMENTATION_PATCH_SIZE = 190;
+    // It seems Kurssisivut only returns max. 10 course implementation per call.
+    private static final int COURSE_IMPLEMENTATION_PATCH_SIZE = 10;
 
     public CoursePageRestClient(String baseUrl, String apiPath, RestTemplate restTemplate) {
         this.baseUrl = baseUrl;

--- a/src/main/java/fi/helsinki/opintoni/integration/coursepage/CoursePageRestClient.java
+++ b/src/main/java/fi/helsinki/opintoni/integration/coursepage/CoursePageRestClient.java
@@ -38,7 +38,7 @@ public class CoursePageRestClient implements CoursePageClient {
 
     private static final Logger log = LoggerFactory.getLogger(CoursePageRestClient.class);
 
-    // It seems Kurssisivut only returns max. 10 course implementation per call.
+    // Course Pages server only returns max. 10 course implementation per call.
     private static final int COURSE_IMPLEMENTATION_PATCH_SIZE = 10;
 
     public CoursePageRestClient(String baseUrl, String apiPath, RestTemplate restTemplate) {


### PR DESCRIPTION
- Now throwing an exception, if not all the requested courses are returned by Course Pages.
- Lowered the batch size for fetching courses from 190 to 10, as Course Pages returns max. 10.
- Modified tests to check that also changes to multiple courses are fetched.