### PR TITLE
OO-1221 Portfolion avatarin muuttaminen portfoliossa

### DIFF
--- a/src/main/java/fi/helsinki/opintoni/integration/obar/ObarJWTService.java
+++ b/src/main/java/fi/helsinki/opintoni/integration/obar/ObarJWTService.java
@@ -17,6 +17,8 @@
 
 package fi.helsinki.opintoni.integration.obar;
 
+import com.google.common.base.Splitter;
+import com.google.common.collect.Iterables;
 import fi.helsinki.opintoni.security.AppUser;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -67,7 +69,7 @@ public class ObarJWTService {
                 firstName = String.join(" ", nameParts.subList(0, nameParts.size() - 1));
             }
             claims.put("user", Map.of(
-                "userName", appUser.getEduPersonPrincipalName().split("@")[0],
+                "userName", Iterables.get(Splitter.on('@').split(appUser.getEduPersonPrincipalName()), 0),
                 "firstName", firstName,
                 "lastName", lastName,
                 "oodiId", appUser.getOodiPersonId()

--- a/src/main/java/fi/helsinki/opintoni/repository/UserRepository.java
+++ b/src/main/java/fi/helsinki/opintoni/repository/UserRepository.java
@@ -35,5 +35,4 @@ public interface UserRepository extends JpaRepository<User, Long> {
         "and u.account_status = 'ACTIVE' " +
         "and (u.account_active_until_date is null or u.account_active_until_date < now())", nativeQuery = true)
     List<User> findInactiveUsers();
-
 }

--- a/src/main/java/fi/helsinki/opintoni/repository/profile/ProfileRepository.java
+++ b/src/main/java/fi/helsinki/opintoni/repository/profile/ProfileRepository.java
@@ -21,6 +21,8 @@ import fi.helsinki.opintoni.domain.profile.Profile;
 import fi.helsinki.opintoni.localization.Language;
 import fi.helsinki.opintoni.web.arguments.ProfileRole;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -37,4 +39,14 @@ public interface ProfileRepository extends JpaRepository<Profile, Long> {
                                                           Language language);
 
     Stream<Profile> findByUserId(Long userId);
+
+    // Optional<byte[]> does not work here, as it will return an Optional<ArrayList<byte[]>>
+    @Query(value = "select u.avatar_image from profile p, user_settings u where p.path = :path and u.user_id = p.user_id limit 1",
+        nativeQuery = true)
+    byte[] getProfileImageByByPath(@Param("path") String path);
+
+    @Query(value = "select u.avatar_image from profile p, user_settings u, profile_shared_link s where " +
+        "s.shared_path_fragment = :sharedLinkFragment and s.profile_id = p.id and u.user_id = p.user_id",
+        nativeQuery = true)
+    byte[] getProfileImageBySharedLinkFragment(@Param("sharedLinkFragment") String sharedLinkFragment);
 }

--- a/src/main/java/fi/helsinki/opintoni/security/authorization/profile/ProfileRequestResolver.java
+++ b/src/main/java/fi/helsinki/opintoni/security/authorization/profile/ProfileRequestResolver.java
@@ -83,7 +83,8 @@ public class ProfileRequestResolver {
     private Optional<ProfileDto> getProfileDtoByShareLink(Map<String, String> templateVariables) {
         ProfileDto profile = profileService.findBySharedLink(
             templateVariables.get(SHARED_LINK_FRAGMENT),
-            ProfileConverter.ComponentFetchStrategy.NONE);
+            ProfileConverter.ComponentFetchStrategy.NONE,
+            ProfileService.ProfileUrlContext.EMPTY);
 
         return Optional.ofNullable(profile);
     }

--- a/src/main/java/fi/helsinki/opintoni/service/AvatarImageService.java
+++ b/src/main/java/fi/helsinki/opintoni/service/AvatarImageService.java
@@ -19,6 +19,7 @@ package fi.helsinki.opintoni.service;
 
 import fi.helsinki.opintoni.domain.UserSettings;
 import fi.helsinki.opintoni.repository.UserSettingsRepository;
+import fi.helsinki.opintoni.service.profile.ProfileService;
 import fi.helsinki.opintoni.util.UriBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -39,6 +40,7 @@ public class AvatarImageService {
         this.uriBuilder = uriBuilder;
     }
 
+    // When Obar is in production use, this should be removed.
     public String getAvatarImageUrl(Long userId) {
         return getAvatarImageUrl(uriBuilder::getDefaultUserAvatarUrl, userId);
     }
@@ -50,8 +52,9 @@ public class AvatarImageService {
             defaultAvatarUrlSupplier.get();
     }
 
-    public String getProfileAvatarImageUrl(Long userId) {
-        return getAvatarImageUrl(uriBuilder::getProfileDefaultUserAvatarUrl, userId);
+    public String getProfileAvatarImageUrl(Long userId, ProfileService.ProfileUrlContext profileUrlContext) {
+        return userSettingsRepository.findByUserId(userId).hasAvatarImage() ?
+            uriBuilder.getProfileAvatarUrl(profileUrlContext) :
+            uriBuilder.getProfileDefaultUserAvatarUrl();
     }
-
 }

--- a/src/main/java/fi/helsinki/opintoni/service/converter/profile/ProfileConverter.java
+++ b/src/main/java/fi/helsinki/opintoni/service/converter/profile/ProfileConverter.java
@@ -86,21 +86,21 @@ public class ProfileConverter {
     }
 
     public ProfileDto toDto(Profile profile, ComponentFetchStrategy componentFetchStrategy) {
-        return toDto(profile, componentFetchStrategy, null);
+        return toDto(profile, componentFetchStrategy, ProfileService.ProfileUrlContext.EMPTY);
     }
 
-    public ProfileDto toDto(Profile profile, ComponentFetchStrategy componentFetchStrategy, String sharedLinkFragment) {
+    public ProfileDto toDto(Profile profile, ComponentFetchStrategy componentFetchStrategy, ProfileService.ProfileUrlContext profileUrlContext) {
         ProfileDto profileDto = new ProfileDto();
         profileDto.id = profile.id;
         profileDto.lang = profile.language.getCode();
-        profileDto.url = sharedLinkFragment == null ?
+        profileDto.url =  profileUrlContext.sharedLinkFragment == null ?
             uriBuilder.getProfileUrl(profile) :
-            uriBuilder.getProfileUrl(profile, sharedLinkFragment);
+            uriBuilder.getProfileUrl(profile, profileUrlContext.sharedLinkFragment);
         profileDto.intro = profile.intro;
         profileDto.ownerName = profile.ownerName;
         profileDto.backgroundUri = profileBackgroundService.getProfileBackgroundUri(profile);
         profileDto.visibility = profile.visibility;
-        profileDto.avatarUrl = avatarImageService.getProfileAvatarImageUrl(profile.getOwnerId());
+        profileDto.avatarUrl = avatarImageService.getProfileAvatarImageUrl(profile.user.id, profileUrlContext);
         profileDto.componentVisibilities = componentVisibilityService.findByProfileId(profile.id);
         profileDto.componentOrders = componentOrderService.findByProfileId(profile.id);
         profileDto.headings = componentHeadingService.findByProfileId(profile.id);

--- a/src/main/java/fi/helsinki/opintoni/util/UriBuilder.java
+++ b/src/main/java/fi/helsinki/opintoni/util/UriBuilder.java
@@ -47,7 +47,7 @@ public class UriBuilder {
     }
 
     public String getProfileAvatarUrl(ProfileService.ProfileUrlContext profileUrlContext) {
-        return getAbsoluteUrl(String.join("/", profileUrlContext.fullPath, "profileimage"));
+        return getAbsoluteUrl(String.join("/", profileUrlContext.fullPath, "profile-image"));
     }
 
     public String getCalendarFeedUrl(String feedId) {
@@ -68,19 +68,19 @@ public class UriBuilder {
     }
 
     public String getProfileUrl(Profile profile) {
-        return String.join("/", profileUrl(profile),
+        return String.join("/", profileBaseUrl(profile),
             profile.language.getCode(), profile.path);
     }
 
     public String getProfileUrl(Profile profile, String sharedLinkFragment) {
-        return String.join("/", profileUrl(profile), sharedLinkFragment);
+        return String.join("/", profileBaseUrl(profile), sharedLinkFragment);
     }
 
     public String getMeceDomain() {
         return appConfiguration.get("mece.domain");
     }
 
-    private String profileUrl(Profile profile) {
+    private String profileBaseUrl(Profile profile) {
         return appConfiguration.get("profileUrl." + profile.profileRole.getRole());
     }
 

--- a/src/main/java/fi/helsinki/opintoni/util/UriBuilder.java
+++ b/src/main/java/fi/helsinki/opintoni/util/UriBuilder.java
@@ -19,6 +19,7 @@ package fi.helsinki.opintoni.util;
 
 import fi.helsinki.opintoni.config.AppConfiguration;
 import fi.helsinki.opintoni.domain.profile.Profile;
+import fi.helsinki.opintoni.service.profile.ProfileService;
 import fi.helsinki.opintoni.web.rest.RestConstants;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -45,6 +46,10 @@ public class UriBuilder {
         return getAbsoluteUrl(RestConstants.PUBLIC_API_V1 + "/images/avatar/" + oodiPersonId);
     }
 
+    public String getProfileAvatarUrl(ProfileService.ProfileUrlContext profileUrlContext) {
+        return getAbsoluteUrl(String.join("/", profileUrlContext.fullPath, "profileimage"));
+    }
+
     public String getCalendarFeedUrl(String feedId) {
         return RestConstants.PUBLIC_API_V1 + "/calendar/" + feedId;
     }
@@ -63,16 +68,20 @@ public class UriBuilder {
     }
 
     public String getProfileUrl(Profile profile) {
-        return String.join("/", appConfiguration.get("profileUrl." + profile.profileRole.getRole()),
+        return String.join("/", profileUrl(profile),
             profile.language.getCode(), profile.path);
     }
 
     public String getProfileUrl(Profile profile, String sharedLinkFragment) {
-        return String.join("/", appConfiguration.get("profileUrl." + profile.profileRole.getRole()), sharedLinkFragment);
+        return String.join("/", profileUrl(profile), sharedLinkFragment);
     }
 
     public String getMeceDomain() {
         return appConfiguration.get("mece.domain");
+    }
+
+    private String profileUrl(Profile profile) {
+        return appConfiguration.get("profileUrl." + profile.profileRole.getRole());
     }
 
 }

--- a/src/main/java/fi/helsinki/opintoni/web/rest/AbstractResource.java
+++ b/src/main/java/fi/helsinki/opintoni/web/rest/AbstractResource.java
@@ -17,7 +17,9 @@
 
 package fi.helsinki.opintoni.web.rest;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
 import java.util.function.Supplier;
@@ -34,5 +36,11 @@ public abstract class AbstractResource {
 
     protected final ResponseEntity noContentResponse() {
         return new ResponseEntity(HttpStatus.NO_CONTENT);
+    }
+
+    protected HttpHeaders headersWithContentType(MediaType contentType) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(contentType);
+        return headers;
     }
 }

--- a/src/main/java/fi/helsinki/opintoni/web/rest/privateapi/profile/PrivateProfileResource.java
+++ b/src/main/java/fi/helsinki/opintoni/web/rest/privateapi/profile/PrivateProfileResource.java
@@ -141,7 +141,7 @@ public class PrivateProfileResource extends AbstractResource {
         return response(profileService.update(profileId, profileDto));
     }
 
-    @RequestMapping(value = "/{profileRole}/{lang}/{path:.*}/profileimage",
+    @RequestMapping(value = "/{profileRole}/{lang}/{path:.*}/profile-image",
         method = RequestMethod.GET,
         produces = MediaType.IMAGE_JPEG_VALUE)
     public ResponseEntity<BufferedImage> getMyProfileImage(@PathVariable("path") String path) {

--- a/src/main/java/fi/helsinki/opintoni/web/rest/publicapi/PublicImageResource.java
+++ b/src/main/java/fi/helsinki/opintoni/web/rest/publicapi/PublicImageResource.java
@@ -20,10 +20,10 @@ package fi.helsinki.opintoni.web.rest.publicapi;
 import com.codahale.metrics.annotation.Timed;
 import fi.helsinki.opintoni.service.BackgroundImageService;
 import fi.helsinki.opintoni.service.UserSettingsService;
+import fi.helsinki.opintoni.service.profile.ProfileService;
 import fi.helsinki.opintoni.web.rest.AbstractResource;
 import fi.helsinki.opintoni.web.rest.RestConstants;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -42,21 +42,23 @@ public class PublicImageResource extends AbstractResource {
 
     private final UserSettingsService userSettingsService;
     private final BackgroundImageService backgroundImageService;
+    private final ProfileService profileService;
 
     @Autowired
     public PublicImageResource(UserSettingsService userSettingsService,
-                               BackgroundImageService backgroundImageService) {
+                               BackgroundImageService backgroundImageService, ProfileService profileService) {
         this.userSettingsService = userSettingsService;
         this.backgroundImageService = backgroundImageService;
+        this.profileService = profileService;
     }
 
+    // When Obar is in production use, this endpoint should be removed.
     @RequestMapping(
         value = "/avatar/{oodiPersonId}",
         method = RequestMethod.GET,
         produces = MediaType.IMAGE_JPEG_VALUE
     )
-    public ResponseEntity<BufferedImage> getUserAvatarByOodiPersonId(@PathVariable("oodiPersonId") String oodiPersonId)
-        throws IOException {
+    public ResponseEntity<BufferedImage> getUserAvatarByOodiPersonId(@PathVariable("oodiPersonId") String oodiPersonId) {
         return ResponseEntity.ok()
             .headers(headersWithContentType(MediaType.IMAGE_JPEG))
             .body(userSettingsService.getUserAvatarImageByOodiPersonId(oodiPersonId));
@@ -89,11 +91,5 @@ public class PublicImageResource extends AbstractResource {
     @Timed
     public ResponseEntity<List<String>> getBackgrounds() throws IOException {
         return response(backgroundImageService.getBackgroundImageFiles());
-    }
-
-    private HttpHeaders headersWithContentType(MediaType contentType) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(contentType);
-        return headers;
     }
 }

--- a/src/main/java/fi/helsinki/opintoni/web/rest/publicapi/profile/PublicProfileResource.java
+++ b/src/main/java/fi/helsinki/opintoni/web/rest/publicapi/profile/PublicProfileResource.java
@@ -26,8 +26,15 @@ import fi.helsinki.opintoni.web.arguments.ProfileRole;
 import fi.helsinki.opintoni.web.rest.AbstractResource;
 import fi.helsinki.opintoni.web.rest.RestConstants;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.awt.image.BufferedImage;
 
 @RestController
 @RequestMapping(
@@ -50,11 +57,36 @@ public class PublicProfileResource extends AbstractResource {
         return response(profileService.findByPathAndLangAndRole(path,
             Language.fromCode(profileLang),
             ProfileRole.fromValue(profileRole),
-            ProfileConverter.ComponentFetchStrategy.PUBLIC));
+            ProfileConverter.ComponentFetchStrategy.PUBLIC,
+            new ProfileService.ProfileUrlContext(String.join("/", RestConstants.PUBLIC_API_V1_PROFILE, profileRole, profileLang, path), null)));
     }
 
     @GetMapping(value = "/shared/{sharedLinkFragment:.*}")
     public ResponseEntity<ProfileDto> getBySharedLink(@PathVariable("sharedLinkFragment") String sharedLinkFragment) {
-        return response(profileService.findBySharedLink(sharedLinkFragment, ProfileConverter.ComponentFetchStrategy.PUBLIC));
+        return response(profileService.findBySharedLink(sharedLinkFragment, ProfileConverter.ComponentFetchStrategy.PUBLIC,
+            new ProfileService.ProfileUrlContext(String.join("/", RestConstants.PUBLIC_API_V1_PROFILE, "shared", sharedLinkFragment),
+                sharedLinkFragment)));
+    }
+
+    @RequestMapping(
+        value = "/{profileRole}/{lang}/{path:.*}/profileimage",
+        method = RequestMethod.GET,
+        produces = MediaType.IMAGE_JPEG_VALUE
+    )
+    public ResponseEntity<BufferedImage> getProfileImageByPath(@PathVariable("path") String path) {
+        return ResponseEntity.ok()
+            .headers(headersWithContentType(MediaType.IMAGE_JPEG))
+            .body(profileService.getProfileImageByPath(path));
+    }
+
+    @RequestMapping(
+        value = "/shared/{sharedLinkFragment:.*}/profileimage",
+        method = RequestMethod.GET,
+        produces = MediaType.IMAGE_JPEG_VALUE
+    )
+    public ResponseEntity<BufferedImage> getProfileImageBySharedLinkFragment(@PathVariable("sharedLinkFragment") String sharedLinkFragment) {
+        return ResponseEntity.ok()
+            .headers(headersWithContentType(MediaType.IMAGE_JPEG))
+            .body(profileService.getProfileImageBySharedLinkFragment(sharedLinkFragment));
     }
 }

--- a/src/main/java/fi/helsinki/opintoni/web/rest/publicapi/profile/PublicProfileResource.java
+++ b/src/main/java/fi/helsinki/opintoni/web/rest/publicapi/profile/PublicProfileResource.java
@@ -69,7 +69,7 @@ public class PublicProfileResource extends AbstractResource {
     }
 
     @RequestMapping(
-        value = "/{profileRole}/{lang}/{path:.*}/profileimage",
+        value = "/{profileRole}/{lang}/{path:.*}/profile-image",
         method = RequestMethod.GET,
         produces = MediaType.IMAGE_JPEG_VALUE
     )
@@ -80,7 +80,7 @@ public class PublicProfileResource extends AbstractResource {
     }
 
     @RequestMapping(
-        value = "/shared/{sharedLinkFragment:.*}/profileimage",
+        value = "/shared/{sharedLinkFragment:.*}/profile-image",
         method = RequestMethod.GET,
         produces = MediaType.IMAGE_JPEG_VALUE
     )

--- a/src/main/java/fi/helsinki/opintoni/web/rest/restrictedapi/profile/RestrictedProfileResource.java
+++ b/src/main/java/fi/helsinki/opintoni/web/rest/restrictedapi/profile/RestrictedProfileResource.java
@@ -61,7 +61,7 @@ public class RestrictedProfileResource extends AbstractResource {
     }
 
     @RequestMapping(
-        value = "/{profileRole}/{lang}/{path:.*}/profileimage",
+        value = "/{profileRole}/{lang}/{path:.*}/profile-image",
         method = RequestMethod.GET,
         produces = MediaType.IMAGE_JPEG_VALUE
     )

--- a/src/main/java/fi/helsinki/opintoni/web/rest/restrictedapi/profile/RestrictedProfileResource.java
+++ b/src/main/java/fi/helsinki/opintoni/web/rest/restrictedapi/profile/RestrictedProfileResource.java
@@ -26,11 +26,14 @@ import fi.helsinki.opintoni.web.arguments.ProfileRole;
 import fi.helsinki.opintoni.web.rest.AbstractResource;
 import fi.helsinki.opintoni.web.rest.RestConstants;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.awt.image.BufferedImage;
 
 @RestController
 @RequestMapping(
@@ -53,7 +56,19 @@ public class RestrictedProfileResource extends AbstractResource {
         return response(profileService.findByPathAndLangAndRole(path,
             Language.fromCode(profileLang),
             ProfileRole.fromValue(profileRole),
-            ProfileConverter.ComponentFetchStrategy.PUBLIC));
+            ProfileConverter.ComponentFetchStrategy.PUBLIC,
+            new ProfileService.ProfileUrlContext(String.join("/", RestConstants.RESTRICTED_API_V1_PROFILE, profileRole, profileLang, path), null)));
+    }
+
+    @RequestMapping(
+        value = "/{profileRole}/{lang}/{path:.*}/profileimage",
+        method = RequestMethod.GET,
+        produces = MediaType.IMAGE_JPEG_VALUE
+    )
+    public ResponseEntity<BufferedImage> getProfileImageByPath(@PathVariable("path") String path) {
+        return ResponseEntity.ok()
+            .headers(headersWithContentType(MediaType.IMAGE_JPEG))
+            .body(profileService.getProfileImageByPath(path));
     }
 
 }

--- a/src/test/java/fi/helsinki/opintoni/service/AvatarImageServiceTest.java
+++ b/src/test/java/fi/helsinki/opintoni/service/AvatarImageServiceTest.java
@@ -48,7 +48,7 @@ public class AvatarImageServiceTest extends SpringTest {
     @Test
     public void thatProfileAvatarImageUrlIsReturned() {
         assertThat(avatarImageService.getProfileAvatarImageUrl(2L, new ProfileService.ProfileUrlContext("/some/fullPath",
-            null))).isEqualTo("https://dev.student.helsinki.fi/some/fullPath/profileimage");
+            null))).isEqualTo("https://dev.student.helsinki.fi/some/fullPath/profile-image");
     }
 
 }

--- a/src/test/java/fi/helsinki/opintoni/service/AvatarImageServiceTest.java
+++ b/src/test/java/fi/helsinki/opintoni/service/AvatarImageServiceTest.java
@@ -18,6 +18,7 @@
 package fi.helsinki.opintoni.service;
 
 import fi.helsinki.opintoni.SpringTest;
+import fi.helsinki.opintoni.service.profile.ProfileService;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -35,7 +36,8 @@ public class AvatarImageServiceTest extends SpringTest {
 
     @Test
     public void thatDefaultProfileAvatarImageUrlIsReturned() {
-        assertThat(avatarImageService.getProfileAvatarImageUrl(1L)).isEqualTo("/profile/assets/icons/avatar.png");
+        assertThat(avatarImageService.getProfileAvatarImageUrl(1L, new ProfileService.ProfileUrlContext("/some/fullPath",
+            null))).isEqualTo("/profile/assets/icons/avatar.png");
     }
 
     @Test
@@ -45,7 +47,8 @@ public class AvatarImageServiceTest extends SpringTest {
 
     @Test
     public void thatProfileAvatarImageUrlIsReturned() {
-        assertThat(avatarImageService.getProfileAvatarImageUrl(2L)).isEqualTo("https://dev.student.helsinki.fi/api/public/v1/images/avatar/200");
+        assertThat(avatarImageService.getProfileAvatarImageUrl(2L, new ProfileService.ProfileUrlContext("/some/fullPath",
+            null))).isEqualTo("https://dev.student.helsinki.fi/some/fullPath/profileimage");
     }
 
 }

--- a/src/test/java/fi/helsinki/opintoni/service/profile/ProfileServiceTest.java
+++ b/src/test/java/fi/helsinki/opintoni/service/profile/ProfileServiceTest.java
@@ -57,6 +57,7 @@ public class ProfileServiceTest extends SpringTest {
     private static final int TEACHER_PROFILE_SECTION_COUNT = TeacherProfileSection.values().length;
     private static final String PUBLIC_VISIBILITY = "PUBLIC";
     private static final String PRIVATE_VISIBILITY = "PRIVATE";
+    private static final String SHARED_LINK_FOR_EXISTING_PORTFOLIO = "a3728b39-7099-4f8c-9413-da2817eeccf9";
 
     @Test
     public void thatProfileIsFoundByPath() {
@@ -123,12 +124,12 @@ public class ProfileServiceTest extends SpringTest {
         String imageBase64 = SampleDataFiles.imageToBase64("usersettings/useravatar.jpg");
         userSettingsService.updateUserAvatar(3L, imageBase64);
 
-        assertThat(profileService.getProfileImageBySharedLinkFragment("a3728b39-7099-4f8c-9413-da2817eeccf9").getHeight() > 120).isTrue();
+        assertThat(profileService.getProfileImageBySharedLinkFragment(SHARED_LINK_FOR_EXISTING_PORTFOLIO).getHeight() > 120).isTrue();
     }
 
     @Test
     public void thatProfileImageIsNotFoundWithSharedLink() throws Exception {
-        assertThatThrownBy(() -> profileService.getProfileImageBySharedLinkFragment("a3728b39-7099-4f8c-9413-da2817eeccf9"))
+        assertThatThrownBy(() -> profileService.getProfileImageBySharedLinkFragment(SHARED_LINK_FOR_EXISTING_PORTFOLIO))
             .isInstanceOf(NotFoundException.class);
     }
 

--- a/src/test/java/fi/helsinki/opintoni/service/profile/ProfileServiceTest.java
+++ b/src/test/java/fi/helsinki/opintoni/service/profile/ProfileServiceTest.java
@@ -22,15 +22,19 @@ import fi.helsinki.opintoni.domain.profile.Profile;
 import fi.helsinki.opintoni.domain.profile.ProfileVisibility;
 import fi.helsinki.opintoni.domain.profile.TeacherProfileSection;
 import fi.helsinki.opintoni.dto.profile.ProfileDto;
+import fi.helsinki.opintoni.exception.http.NotFoundException;
 import fi.helsinki.opintoni.localization.Language;
 import fi.helsinki.opintoni.repository.profile.ComponentVisibilityRepository;
 import fi.helsinki.opintoni.repository.profile.ProfileRepository;
+import fi.helsinki.opintoni.sampledata.SampleDataFiles;
+import fi.helsinki.opintoni.service.UserSettingsService;
 import fi.helsinki.opintoni.service.converter.profile.ProfileConverter;
 import fi.helsinki.opintoni.web.arguments.ProfileRole;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
 
 public class ProfileServiceTest extends SpringTest {
@@ -46,6 +50,9 @@ public class ProfileServiceTest extends SpringTest {
 
     @Autowired
     private ProfileRepository profileRepository;
+
+    @Autowired
+    private UserSettingsService userSettingsService;
 
     private static final int TEACHER_PROFILE_SECTION_COUNT = TeacherProfileSection.values().length;
     private static final String PUBLIC_VISIBILITY = "PUBLIC";
@@ -96,6 +103,33 @@ public class ProfileServiceTest extends SpringTest {
                 tuple("RESEARCH", PRIVATE_VISIBILITY),
                 tuple("TEACHING", PRIVATE_VISIBILITY),
                 tuple("ADMINISTRATION", PRIVATE_VISIBILITY));
+    }
+
+    @Test
+    public void thatProfileImageIsFound() throws Exception {
+        String imageBase64 = SampleDataFiles.imageToBase64("usersettings/useravatar.jpg");
+        userSettingsService.updateUserAvatar(2L, imageBase64);
+
+        assertThat(profileService.getProfileImageByPath("pekka").getHeight() > 120).isTrue();
+    }
+
+    @Test
+    public void thatProfileImageIsNotFound() throws Exception {
+        assertThatThrownBy(() -> profileService.getProfileImageByPath("pekka")).isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    public void thatProfileImageIsFoundWithSharedLink() throws Exception {
+        String imageBase64 = SampleDataFiles.imageToBase64("usersettings/useravatar.jpg");
+        userSettingsService.updateUserAvatar(3L, imageBase64);
+
+        assertThat(profileService.getProfileImageBySharedLinkFragment("a3728b39-7099-4f8c-9413-da2817eeccf9").getHeight() > 120).isTrue();
+    }
+
+    @Test
+    public void thatProfileImageIsNotFoundWithSharedLink() throws Exception {
+        assertThatThrownBy(() -> profileService.getProfileImageBySharedLinkFragment("a3728b39-7099-4f8c-9413-da2817eeccf9"))
+            .isInstanceOf(NotFoundException.class);
     }
 
     private void deleteExistingTeacherProfile() {

--- a/src/test/java/fi/helsinki/opintoni/web/rest/privateapi/profile/AbstractProfileResourceTest.java
+++ b/src/test/java/fi/helsinki/opintoni/web/rest/privateapi/profile/AbstractProfileResourceTest.java
@@ -19,7 +19,11 @@ package fi.helsinki.opintoni.web.rest.privateapi.profile;
 
 import fi.helsinki.opintoni.SpringTest;
 import fi.helsinki.opintoni.localization.Language;
+import fi.helsinki.opintoni.sampledata.SampleDataFiles;
+import fi.helsinki.opintoni.service.UserSettingsService;
 import fi.helsinki.opintoni.web.rest.RestConstants;
+import org.junit.Before;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.test.web.servlet.ResultActions;
@@ -34,8 +38,21 @@ public abstract class AbstractProfileResourceTest extends SpringTest {
     protected static final String STUDENT_PROFILE_API_PATH = PRIVATE_PROFILE_API_PATH + "/student";
     protected static final String TEACHER_PROFILE_API_PATH = PRIVATE_PROFILE_API_PATH + "/teacher";
     protected static final String SESSION_LANG = EN.getCode();
+    protected static final String ABSOLUTE = "https://dev.student.helsinki.fi";
+    protected static final String ABSOLUTE_PUBLIC_API_PATH = ABSOLUTE + RestConstants.PUBLIC_API_V1;
+    protected static final String ABSOLUTE_RESTRICTED_API_PATH = ABSOLUTE + RestConstants.RESTRICTED_API_V1;
+    protected static final String PROFILE_IMAGE = "/profileimage";
 
     private static final String EMPLOYEE_NUMBER = "010540";
+
+    @Autowired
+    private UserSettingsService userSettingsService;
+
+    @Before
+    public final void addAvatars() {
+        userSettingsService.updateUserAvatar(3L, getAvatarImageData()); // olli-opiskelija
+        userSettingsService.updateUserAvatar(4L, getAvatarImageData()); // opettaja
+    }
 
     protected ResultActions createProfile(SecurityContext securityContext, String apiUrl) throws Exception {
         return mockMvc.perform(post(apiUrl)
@@ -64,5 +81,9 @@ public abstract class AbstractProfileResourceTest extends SpringTest {
 
     protected void expectEmployeeContactInformationRequestToESB() {
         esbServer.expectEmployeeContactInformationRequest(EMPLOYEE_NUMBER);
+    }
+
+    protected String getAvatarImageData() {
+        return SampleDataFiles.imageToBase64("usersettings/useravatar.jpg");
     }
 }

--- a/src/test/java/fi/helsinki/opintoni/web/rest/privateapi/profile/AbstractProfileResourceTest.java
+++ b/src/test/java/fi/helsinki/opintoni/web/rest/privateapi/profile/AbstractProfileResourceTest.java
@@ -38,10 +38,10 @@ public abstract class AbstractProfileResourceTest extends SpringTest {
     protected static final String STUDENT_PROFILE_API_PATH = PRIVATE_PROFILE_API_PATH + "/student";
     protected static final String TEACHER_PROFILE_API_PATH = PRIVATE_PROFILE_API_PATH + "/teacher";
     protected static final String SESSION_LANG = EN.getCode();
-    protected static final String ABSOLUTE = "https://dev.student.helsinki.fi";
-    protected static final String ABSOLUTE_PUBLIC_API_PATH = ABSOLUTE + RestConstants.PUBLIC_API_V1;
-    protected static final String ABSOLUTE_RESTRICTED_API_PATH = ABSOLUTE + RestConstants.RESTRICTED_API_V1;
-    protected static final String PROFILE_IMAGE = "/profileimage";
+    protected static final String ABSOLUTE_BASE_URL = "https://dev.student.helsinki.fi";
+    protected static final String ABSOLUTE_PUBLIC_API_PATH = ABSOLUTE_BASE_URL + RestConstants.PUBLIC_API_V1;
+    protected static final String ABSOLUTE_RESTRICTED_API_PATH = ABSOLUTE_BASE_URL + RestConstants.RESTRICTED_API_V1;
+    protected static final String PROFILE_IMAGE = "/profile-image";
 
     private static final String EMPLOYEE_NUMBER = "010540";
 

--- a/src/test/java/fi/helsinki/opintoni/web/rest/privateapi/profile/PrivateProfileResourceTest.java
+++ b/src/test/java/fi/helsinki/opintoni/web/rest/privateapi/profile/PrivateProfileResourceTest.java
@@ -19,9 +19,16 @@ package fi.helsinki.opintoni.web.rest.privateapi.profile;
 
 import fi.helsinki.opintoni.domain.profile.ProfileComponent;
 import fi.helsinki.opintoni.domain.profile.ProfileVisibility;
-import fi.helsinki.opintoni.dto.profile.*;
+import fi.helsinki.opintoni.dto.profile.ComponentOrderDto;
+import fi.helsinki.opintoni.dto.profile.DegreeDto;
+import fi.helsinki.opintoni.dto.profile.FreeTextContentDto;
+import fi.helsinki.opintoni.dto.profile.KeywordDto;
+import fi.helsinki.opintoni.dto.profile.LanguageProficiencyDto;
+import fi.helsinki.opintoni.dto.profile.ProfileDto;
+import fi.helsinki.opintoni.dto.profile.WorkExperienceDto;
 import fi.helsinki.opintoni.localization.Language;
 import fi.helsinki.opintoni.repository.profile.ProfileRepository;
+import fi.helsinki.opintoni.service.UserSettingsService;
 import fi.helsinki.opintoni.service.profile.ProfileService;
 import fi.helsinki.opintoni.web.WebConstants;
 import fi.helsinki.opintoni.web.WebTestUtils;
@@ -33,12 +40,23 @@ import org.springframework.http.MediaType;
 import java.util.List;
 
 import static fi.helsinki.opintoni.security.SecurityRequestPostProcessors.securityContext;
-import static fi.helsinki.opintoni.security.TestSecurityContext.*;
+import static fi.helsinki.opintoni.security.TestSecurityContext.hybridUserSecurityContext;
+import static fi.helsinki.opintoni.security.TestSecurityContext.studentSecurityContext;
+import static fi.helsinki.opintoni.security.TestSecurityContext.teacherSecurityContext;
+import static fi.helsinki.opintoni.security.TestSecurityContext.teacherWithoutProfileSecurityContext;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isOneOf;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class PrivateProfileResourceTest extends AbstractProfileResourceTest {
 
@@ -46,12 +64,17 @@ public class PrivateProfileResourceTest extends AbstractProfileResourceTest {
     private static final String TEACHER_PROFILE_PATH = "/profile/en/olli-opettaja";
     private static final String HYBRID_USER_PROFILE_PATH = "/profile/en/hybrid-user";
     private static final String STUDENT_EMAIL = "olli.opiskelija@helsinki.fi";
+    private static final String OLLI_PROFILE = PRIVATE_PROFILE_API_PATH + "/student/en/olli-opiskelija";
+    private static final String OLLI_PROFILE_IMAGE = OLLI_PROFILE + "/profileimage";
 
     @Autowired
     private ProfileRepository profileRepository;
 
     @Autowired
     private ProfileService profileService;
+
+    @Autowired
+    private UserSettingsService userSettingsService;
 
     @Test
     public void thatAnyExistingOwnProfileIsReturnedWhenQueryingByRoleOnly() throws Exception {
@@ -62,8 +85,10 @@ public class PrivateProfileResourceTest extends AbstractProfileResourceTest {
 
     @Test
     public void thatStudentProfileContainsAllLinkedComponents() throws Exception {
-        mockMvc.perform(get(STUDENT_PROFILE_API_PATH + "/en/olli-opiskelija")
+        mockMvc.perform(get(OLLI_PROFILE)
                 .with(securityContext(studentSecurityContext())))
+                .andExpect(jsonPath("$.avatarUrl").value(
+                ABSOLUTE + OLLI_PROFILE_IMAGE))
                 .andExpect(jsonPath("$.contactInformation").value(
                         both(hasEntry("email", STUDENT_EMAIL)).and(hasEntry("phoneNumber", "+358112223333"))
                 ))
@@ -364,6 +389,21 @@ public class PrivateProfileResourceTest extends AbstractProfileResourceTest {
 
         assertThat(profileService.findById(2L).visibility)
                 .isEqualTo(ProfileVisibility.PUBLIC);
+    }
+
+    @Test
+    public void thatOwnProfileImageIsReturned() throws Exception {
+        mockMvc.perform(get(OLLI_PROFILE_IMAGE)
+            .with(securityContext(studentSecurityContext())))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.IMAGE_JPEG_VALUE));
+    }
+
+    @Test
+    public void thatSomeOtherProfileImageIsNotReturned() throws Exception {
+        mockMvc.perform(get(OLLI_PROFILE_IMAGE)
+            .with(securityContext(teacherSecurityContext())))
+            .andExpect(status().isNotFound());
     }
 
     private void deleteExistingStudentProfiles() {

--- a/src/test/java/fi/helsinki/opintoni/web/rest/privateapi/profile/PrivateProfileResourceTest.java
+++ b/src/test/java/fi/helsinki/opintoni/web/rest/privateapi/profile/PrivateProfileResourceTest.java
@@ -65,7 +65,7 @@ public class PrivateProfileResourceTest extends AbstractProfileResourceTest {
     private static final String HYBRID_USER_PROFILE_PATH = "/profile/en/hybrid-user";
     private static final String STUDENT_EMAIL = "olli.opiskelija@helsinki.fi";
     private static final String OLLI_PROFILE = PRIVATE_PROFILE_API_PATH + "/student/en/olli-opiskelija";
-    private static final String OLLI_PROFILE_IMAGE = OLLI_PROFILE + "/profileimage";
+    private static final String OLLI_PROFILE_IMAGE = OLLI_PROFILE + "/profile-image";
 
     @Autowired
     private ProfileRepository profileRepository;
@@ -88,7 +88,7 @@ public class PrivateProfileResourceTest extends AbstractProfileResourceTest {
         mockMvc.perform(get(OLLI_PROFILE)
                 .with(securityContext(studentSecurityContext())))
                 .andExpect(jsonPath("$.avatarUrl").value(
-                ABSOLUTE + OLLI_PROFILE_IMAGE))
+                ABSOLUTE_BASE_URL + OLLI_PROFILE_IMAGE))
                 .andExpect(jsonPath("$.contactInformation").value(
                         both(hasEntry("email", STUDENT_EMAIL)).and(hasEntry("phoneNumber", "+358112223333"))
                 ))

--- a/src/test/java/fi/helsinki/opintoni/web/rest/publicapi/profile/PublicProfileTest.java
+++ b/src/test/java/fi/helsinki/opintoni/web/rest/publicapi/profile/PublicProfileTest.java
@@ -17,10 +17,22 @@
 
 package fi.helsinki.opintoni.web.rest.publicapi.profile;
 
-import fi.helsinki.opintoni.SpringTest;
-import fi.helsinki.opintoni.domain.profile.*;
-import fi.helsinki.opintoni.repository.profile.*;
+import fi.helsinki.opintoni.domain.profile.ComponentVisibility;
+import fi.helsinki.opintoni.domain.profile.Degree;
+import fi.helsinki.opintoni.domain.profile.Profile;
+import fi.helsinki.opintoni.domain.profile.ProfileComponent;
+import fi.helsinki.opintoni.domain.profile.ProfileLanguageProficiency;
+import fi.helsinki.opintoni.domain.profile.ProfileVisibility;
+import fi.helsinki.opintoni.domain.profile.Sample;
+import fi.helsinki.opintoni.domain.profile.WorkExperience;
+import fi.helsinki.opintoni.repository.profile.ComponentVisibilityRepository;
+import fi.helsinki.opintoni.repository.profile.DegreeRepository;
+import fi.helsinki.opintoni.repository.profile.LanguageProficiencyRepository;
+import fi.helsinki.opintoni.repository.profile.ProfileRepository;
+import fi.helsinki.opintoni.repository.profile.SampleRepository;
+import fi.helsinki.opintoni.repository.profile.WorkExperienceRepository;
 import fi.helsinki.opintoni.web.rest.RestConstants;
+import fi.helsinki.opintoni.web.rest.privateapi.profile.AbstractProfileResourceTest;
 import org.junit.Before;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -29,7 +41,7 @@ import java.util.List;
 
 import static java.util.stream.Collectors.toList;
 
-public abstract class PublicProfileTest extends SpringTest {
+public abstract class PublicProfileTest extends AbstractProfileResourceTest {
 
     protected static final String PUBLIC_STUDENT_PROFILE_API_PATH = RestConstants.PUBLIC_API_V1 + "/profile/2";
 

--- a/src/test/java/fi/helsinki/opintoni/web/rest/restrictedapi/profile/RestrictedProfileComponentVisibilityTest.java
+++ b/src/test/java/fi/helsinki/opintoni/web/rest/restrictedapi/profile/RestrictedProfileComponentVisibilityTest.java
@@ -17,7 +17,6 @@
 
 package fi.helsinki.opintoni.web.rest.restrictedapi.profile;
 
-import org.junit.Before;
 import org.junit.Test;
 
 import static fi.helsinki.opintoni.security.SecurityRequestPostProcessors.securityContext;
@@ -27,13 +26,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 public class RestrictedProfileComponentVisibilityTest extends RestrictedProfileTest {
 
-    @Before
-    public void init() {
-        setPrivateVisibilitiesForEveryComponent();
-    }
-
     @Test
     public void thatPrivateAttainmentsAreNotReturned() throws Exception {
+        setPrivateVisibilitiesForEveryComponent();
         returnsForbidden(RESTRICTED_STUDENT_PROFILE_API_PATH + "/attainment");
     }
 

--- a/src/test/java/fi/helsinki/opintoni/web/rest/restrictedapi/profile/RestrictedProfileResourceTest.java
+++ b/src/test/java/fi/helsinki/opintoni/web/rest/restrictedapi/profile/RestrictedProfileResourceTest.java
@@ -42,7 +42,7 @@ public class RestrictedProfileResourceTest extends RestrictedProfileTest {
 
     private static final String STUDENT_PROFILE_PATH = "/profile/student/en/olli-opiskelija";
     private static final String TEACHER_PROFILE_PATH = "/profile/teacher/fi/opettaja";
-
+    private static final String STUDENT_PROFILE_IMAGE_PATH = RestConstants.RESTRICTED_API_V1 + STUDENT_PROFILE_PATH + "/profile-image";
     private static final String PUBLIC_FREE_TEXT_CONTENT_ITEM_INSTANCE_NAME = "4c024239-8dab-4ea0-a686-fe373b040f48";
 
     @Test
@@ -124,7 +124,7 @@ public class RestrictedProfileResourceTest extends RestrictedProfileTest {
 
     @Test
     public void thatProfileImageIsReturned() throws Exception {
-        mockMvc.perform(get(RestConstants.RESTRICTED_API_V1 + STUDENT_PROFILE_PATH + "/profileimage")
+        mockMvc.perform(get(STUDENT_PROFILE_IMAGE_PATH)
             .with(securityContext(teacherSecurityContext())))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.IMAGE_JPEG_VALUE));
@@ -132,14 +132,14 @@ public class RestrictedProfileResourceTest extends RestrictedProfileTest {
 
     @Test
     public void thatProfileImageIsNotReturnedIfNotLoggedIn() throws Exception {
-        mockMvc.perform(get(RestConstants.RESTRICTED_API_V1 + STUDENT_PROFILE_PATH + "/profileimage"))
+        mockMvc.perform(get(STUDENT_PROFILE_IMAGE_PATH))
             .andExpect(status().isUnauthorized());
     }
 
     @Test
     public void thatProfileImageIsNotReturnedIfPrivate() throws Exception {
         saveProfileWithVisibility(STUDENT_PROFILE_ID, ProfileVisibility.PRIVATE);
-        mockMvc.perform(get(RestConstants.RESTRICTED_API_V1 + STUDENT_PROFILE_PATH + "/profileimage")
+        mockMvc.perform(get(STUDENT_PROFILE_IMAGE_PATH)
             .with(securityContext(teacherSecurityContext())))
             .andExpect(status().isNotFound())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE));

--- a/src/test/java/fi/helsinki/opintoni/web/rest/restrictedapi/profile/RestrictedProfileTest.java
+++ b/src/test/java/fi/helsinki/opintoni/web/rest/restrictedapi/profile/RestrictedProfileTest.java
@@ -17,7 +17,6 @@
 
 package fi.helsinki.opintoni.web.rest.restrictedapi.profile;
 
-import fi.helsinki.opintoni.SpringTest;
 import fi.helsinki.opintoni.domain.profile.ComponentVisibility;
 import fi.helsinki.opintoni.domain.profile.Profile;
 import fi.helsinki.opintoni.domain.profile.ProfileComponent;
@@ -25,12 +24,13 @@ import fi.helsinki.opintoni.domain.profile.ProfileVisibility;
 import fi.helsinki.opintoni.repository.profile.ComponentVisibilityRepository;
 import fi.helsinki.opintoni.repository.profile.ProfileRepository;
 import fi.helsinki.opintoni.web.rest.RestConstants;
+import fi.helsinki.opintoni.web.rest.privateapi.profile.AbstractProfileResourceTest;
 import org.junit.Before;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Arrays;
 
-public abstract class RestrictedProfileTest extends SpringTest {
+public abstract class RestrictedProfileTest extends AbstractProfileResourceTest {
 
     protected static final String RESTRICTED_STUDENT_PROFILE_API_PATH = RestConstants.RESTRICTED_API_V1 + "/profile/2";
     protected static final long STUDENT_PROFILE_ID = 2L;
@@ -43,7 +43,11 @@ public abstract class RestrictedProfileTest extends SpringTest {
     private ComponentVisibilityRepository componentVisibilityRepository;
 
     @Before
-    public void saveStudentProfileAsRestricted() {
+    public final void init() {
+        saveStudentProfileAsRestricted();
+    }
+
+    private void saveStudentProfileAsRestricted() {
         saveProfileAsRestricted(STUDENT_PROFILE_ID);
     }
 
@@ -64,8 +68,16 @@ public abstract class RestrictedProfileTest extends SpringTest {
     }
 
     private void saveProfileAsRestricted(long profileId) {
+        saveProfileWithVisibility(profileId, ProfileVisibility.RESTRICTED);
+    }
+
+    private void saveProfileAsPrivate(long profileId) {
+        saveProfileWithVisibility(profileId, ProfileVisibility.PRIVATE);
+    }
+
+    protected void saveProfileWithVisibility(long profileId, ProfileVisibility visibility) {
         Profile profile = profileRepository.findById(profileId).get();
-        profile.visibility = ProfileVisibility.RESTRICTED;
+        profile.visibility = visibility;
         profileRepository.save(profile);
     }
 }


### PR DESCRIPTION
- Porftolio avatar image can now be changed in the Portfolio UI. Image URL now has authorization as it depends on the portfolio context: public, restricted or private. The current unauthenticated avatar image access endpoint will be removed in ticket https://jira.it.helsinki.fi/browse/OO-1299
- Removed web cam feature from avatar change because it was broken and not required.

Other:
- Fixed a checkstyle warning in ObarJWTService.java
- Did some housekeeping and reorganizing in integration test classes.
- Sped up dev frontend startup.
- Fixed an undefined reference bug in portfolio StateService, which manifested itself when logged in and viewing a restricted profile.
- Added a couple of aria-labels to icons.