### PR TITLE
OO-1419 Kurssisivulinkki jäänyt muodostumatta tuotannossa

### DIFF
--- a/src/main/java/fi/helsinki/opintoni/task/CourseImplementationCacheUpdaterScheduler.java
+++ b/src/main/java/fi/helsinki/opintoni/task/CourseImplementationCacheUpdaterScheduler.java
@@ -23,7 +23,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
-@ConditionalOnProperty("coursePage.checkUpdates.interval.seconds")
+@ConditionalOnProperty("coursePage.updateIntervalInSeconds")
 public class CourseImplementationCacheUpdaterScheduler {
     private final CourseImplementationCacheUpdater courseImplementationCacheUpdater;
 
@@ -32,7 +32,7 @@ public class CourseImplementationCacheUpdaterScheduler {
         this.courseImplementationCacheUpdater = courseImplementationCacheUpdater;
     }
 
-    @Scheduled(fixedDelayString = "${coursePage.checkUpdates.interval.seconds}000")
+    @Scheduled(fixedDelayString = "${coursePage.updateIntervalInSeconds}000")
     public void getCourseImplementationChangesAndUpdateCache() {
         courseImplementationCacheUpdater.getCourseImplementationChangesAndUpdateCache();
     }

--- a/src/test/java/fi/helsinki/opintoni/util/DateTimeUtilTest.java
+++ b/src/test/java/fi/helsinki/opintoni/util/DateTimeUtilTest.java
@@ -17,8 +17,11 @@
 
 package fi.helsinki.opintoni.util;
 
+import fi.helsinki.opintoni.integration.coursepage.CoursePageCourseImplementation;
 import org.junit.Test;
 
+import java.io.FileInputStream;
+import java.io.ObjectInputStream;
 import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -57,4 +60,20 @@ public class DateTimeUtilTest  {
         assertThat(DateTimeUtil.getSemesterStartDateString(d)).isEqualTo(EXPECTED_DATE_STRING);
     }
 
+    @Test
+    public void forManuallyInspectingASerializedCoursePageCourseImplementationFromRedis()  {
+        FileInputStream fileInStream = null;
+        try {
+            // on the server see the password in /opt/opintoni/config/application.properties and:
+            // redis-cli --raw -h localhost -a 'password' get "coursePage::129620052_fi" > /tmp/file.bin
+            // then copy the file over to local disk /tmp
+            fileInStream = new FileInputStream("/tmp/file.bin");
+            ObjectInputStream ois = new ObjectInputStream(fileInStream);
+            CoursePageCourseImplementation myClass2 = (CoursePageCourseImplementation) ois.readObject();
+            // Put a breakpoint on the next line and debug this test.
+            ois.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
 }

--- a/src/test/java/fi/helsinki/opintoni/util/DateTimeUtilTest.java
+++ b/src/test/java/fi/helsinki/opintoni/util/DateTimeUtilTest.java
@@ -17,11 +17,8 @@
 
 package fi.helsinki.opintoni.util;
 
-import fi.helsinki.opintoni.integration.coursepage.CoursePageCourseImplementation;
 import org.junit.Test;
 
-import java.io.FileInputStream;
-import java.io.ObjectInputStream;
 import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -58,22 +55,5 @@ public class DateTimeUtilTest  {
     public void thatLastSemesterStringIsObtainedCorrectlyAfterFirstOfMay() {
         LocalDate d = LocalDate.of(2016, 7, 1);
         assertThat(DateTimeUtil.getSemesterStartDateString(d)).isEqualTo(EXPECTED_DATE_STRING);
-    }
-
-    @Test
-    public void forManuallyInspectingASerializedCoursePageCourseImplementationFromRedis()  {
-        FileInputStream fileInStream = null;
-        try {
-            // on the server see the password in /opt/opintoni/config/application.properties and:
-            // redis-cli --raw -h localhost -a 'password' get "coursePage::129620052_fi" > /tmp/file.bin
-            // then copy the file over to local disk /tmp
-            fileInStream = new FileInputStream("/tmp/file.bin");
-            ObjectInputStream ois = new ObjectInputStream(fileInStream);
-            CoursePageCourseImplementation myClass2 = (CoursePageCourseImplementation) ois.readObject();
-            // Put a breakpoint on the next line and debug this test.
-            ois.close();
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
     }
 }


### PR DESCRIPTION
- OO was not fetching course page changes due to misconfiguration.
- Added a unit test that can be manually run to read serialized CoursePageCourseImplementation objects from file.