### PR TITLE
https://jira.it.helsinki.fi/browse/OO-1510 OodiUid -> hyPersonSisuId

### DIFF
--- a/src/main/java/fi/helsinki/opintoni/config/WebConfig.java
+++ b/src/main/java/fi/helsinki/opintoni/config/WebConfig.java
@@ -68,9 +68,6 @@ public class WebConfig implements WebMvcConfigurer {
     @Autowired
     private AutowireCapableBeanFactory beanFactory;
 
-    @Autowired
-    private AppConfiguration appConfiguration;
-
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
         argumentResolvers.addAll(Lists.newArrayList(
@@ -78,7 +75,7 @@ public class WebConfig implements WebMvcConfigurer {
             new StudentNumberArgumentResolver(securityUtils),
             new PersonIdArgumentResolver(securityUtils),
             new UserIdArgumentResolver(userService, securityUtils),
-            new UsernameArgumentResolver(userService, securityUtils)));
+            new UsernameArgumentResolver(securityUtils)));
     }
 
     @Override

--- a/src/main/java/fi/helsinki/opintoni/integration/IntegrationUtil.java
+++ b/src/main/java/fi/helsinki/opintoni/integration/IntegrationUtil.java
@@ -25,8 +25,6 @@ public final class IntegrationUtil {
     public static final String SISU_COURSE_UNIT_REALISATION_FROM_OPTIME_ID_PREFIX = "hy-opt-cur-";
     public static final String SISU_COURSE_UNIT_REALISATION_PREFIX = "otm-";
 
-    public static final String SISU_PRIVATE_PERSON_ID_PREFIX = "hy-hlo-";
-
     public static String getSisuCourseUnitRealisationId(String id) {
         if (StringUtils.startsWithAny(id,
             SISU_COURSE_UNIT_REALISATION_FROM_OODI_ID_PREFIX,
@@ -35,13 +33,6 @@ public final class IntegrationUtil {
             return id;
         }
         return SISU_COURSE_UNIT_REALISATION_FROM_OODI_ID_PREFIX + id;
-    }
-
-    public static String getSisuPrivatePersonId(String id) {
-        if (StringUtils.startsWithIgnoreCase(id, SISU_PRIVATE_PERSON_ID_PREFIX)) {
-            return id;
-        }
-        return SISU_PRIVATE_PERSON_ID_PREFIX + id;
     }
 
     public static String stripPossibleSisuOodiCurPrefix(String curId) {

--- a/src/main/java/fi/helsinki/opintoni/integration/obar/ObarJWTService.java
+++ b/src/main/java/fi/helsinki/opintoni/integration/obar/ObarJWTService.java
@@ -68,8 +68,7 @@ public class ObarJWTService {
             claims.put("user", Map.of(
                 "userName", Iterables.get(Splitter.on('@').split(appUser.getEduPersonPrincipalName()), 0),
                 "firstName", firstName,
-                "lastName", lastName,
-                "oodiId", appUser.getPersonId()
+                "lastName", lastName
             ));
         }
         return Jwts.builder().setClaims(claims).setExpiration(getExpirationDate()).signWith(signatureAlgorithm, obarSecretKey).compact();

--- a/src/main/java/fi/helsinki/opintoni/integration/optime/OptimeService.java
+++ b/src/main/java/fi/helsinki/opintoni/integration/optime/OptimeService.java
@@ -20,8 +20,6 @@ package fi.helsinki.opintoni.integration.optime;
 import fi.helsinki.opintoni.cache.CacheConstants;
 import fi.helsinki.opintoni.dto.EventDto;
 import fi.helsinki.opintoni.service.converter.EventConverter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
@@ -32,8 +30,6 @@ import java.util.List;
 
 @Service
 public class OptimeService {
-
-    private static final Logger logger = LoggerFactory.getLogger(OptimeService.class);
 
     private final EventConverter eventConverter;
     private final OptimeClient optimeClient;

--- a/src/main/java/fi/helsinki/opintoni/integration/studyregistry/StudyRegistry.java
+++ b/src/main/java/fi/helsinki/opintoni/integration/studyregistry/StudyRegistry.java
@@ -26,13 +26,13 @@ public interface StudyRegistry {
 
     List<Event> getStudentEvents(String studentNumber);
 
-    List<Event> getTeacherEvents(String teacherNumber);
+    List<Event> getTeacherEvents(String personId);
 
     List<StudyAttainment> getStudyAttainments(String personId);
 
     List<StudyAttainment> getStudyAttainments(String personId, String studentNumber);
 
-    List<TeacherCourse> getTeacherCourses(String teacherNumber, LocalDate sinceDate);
+    List<TeacherCourse> getTeacherCourses(String personId, LocalDate sinceDate);
 
     List<StudyRight> getStudentStudyRights(String studentNumber);
 

--- a/src/main/java/fi/helsinki/opintoni/integration/studyregistry/StudyRegistryService.java
+++ b/src/main/java/fi/helsinki/opintoni/integration/studyregistry/StudyRegistryService.java
@@ -62,8 +62,8 @@ public class StudyRegistryService {
     }
 
     @Cacheable(value = CacheConstants.TEACHER_EVENTS, cacheManager = "transientCacheManager")
-    public List<Event> getTeacherEvents(String teacherNumber) {
-        return sisuStudyRegistry.getTeacherEvents(teacherNumber);
+    public List<Event> getTeacherEvents(String personId) {
+        return sisuStudyRegistry.getTeacherEvents(personId);
     }
 
     @Cacheable(value = CacheConstants.STUDY_ATTAINMENTS, cacheManager = "transientCacheManager")
@@ -77,8 +77,8 @@ public class StudyRegistryService {
     }
 
     @Cacheable(value = CacheConstants.TEACHER_COURSES, cacheManager = "transientCacheManager")
-    public List<TeacherCourse> getTeacherCourses(String teacherNumber, LocalDate sinceDate) {
-        return sisuStudyRegistry.getTeacherCourses(teacherNumber, sinceDate);
+    public List<TeacherCourse> getTeacherCourses(String personId, LocalDate sinceDate) {
+        return sisuStudyRegistry.getTeacherCourses(personId, sinceDate);
     }
 
     @Cacheable(value = CacheConstants.STUDY_RIGHTS, cacheManager = "transientCacheManager")

--- a/src/main/java/fi/helsinki/opintoni/integration/studyregistry/sisu/SisuGraphQLClient.java
+++ b/src/main/java/fi/helsinki/opintoni/integration/studyregistry/sisu/SisuGraphQLClient.java
@@ -31,7 +31,6 @@ import org.springframework.http.MediaType;
 import org.springframework.web.client.RestTemplate;
 
 import fi.helsinki.opintoni.cache.CacheConstants;
-import fi.helsinki.opintoni.integration.IntegrationUtil;
 import fi.helsinki.opintoni.integration.studyregistry.sisu.model.AcceptorPersonResponseProjection;
 import fi.helsinki.opintoni.integration.studyregistry.sisu.model.AddressResponseProjection;
 import fi.helsinki.opintoni.integration.studyregistry.sisu.model.AttainmentResponseProjection;
@@ -162,9 +161,6 @@ public class SisuGraphQLClient implements SisuClient {
     @Cacheable(value = CacheConstants.GRAPHQL_STUDY_ATTAINMENTS, cacheManager = "transientCacheManager", sync = true)
     @Override
     public Private_personQueryResponse getStudyAttainments(String personId) {
-        if (!personId.startsWith(IntegrationUtil.SISU_PRIVATE_PERSON_ID_PREFIX)) {
-            throw new IllegalArgumentException(String.format("Illegal sisu personId : %s", personId));
-        }
         GraphQLOperationRequest qr = new Private_personQueryRequest.Builder().setId(personId).build();
         PrivatePersonResponseProjection projection =  new PrivatePersonResponseProjection()
             .studentNumber()

--- a/src/main/java/fi/helsinki/opintoni/integration/studyregistry/sisu/SisuStudyRegistry.java
+++ b/src/main/java/fi/helsinki/opintoni/integration/studyregistry/sisu/SisuStudyRegistry.java
@@ -27,7 +27,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
-import fi.helsinki.opintoni.integration.IntegrationUtil;
 import fi.helsinki.opintoni.integration.studyregistry.Enrollment;
 import fi.helsinki.opintoni.integration.studyregistry.Event;
 import fi.helsinki.opintoni.integration.studyregistry.Person;
@@ -62,14 +61,14 @@ public class SisuStudyRegistry implements StudyRegistry {
     }
 
     @Override
-    public List<Event> getTeacherEvents(String teacherNumber) {
+    public List<Event> getTeacherEvents(String personId) {
         return sisuStudyRegistryConverter.sisuCurSearchResultToEvents(
-            sisuClient.curSearch(teacherNumber, LocalDate.now(ZoneId.of("Europe/Helsinki"))), teacherNumber);
+            sisuClient.curSearch(personId, LocalDate.now(ZoneId.of("Europe/Helsinki"))), personId);
     }
 
     @Override
     public List<StudyAttainment> getStudyAttainments(String personId) {
-        Private_personQueryResponse res = sisuClient.getStudyAttainments(IntegrationUtil.getSisuPrivatePersonId(personId));
+        Private_personQueryResponse res = sisuClient.getStudyAttainments(personId);
         return res.private_person().getAttainments().stream()
             .filter(a -> Objects.nonNull(a.getCourseUnit()))
             .map(sisuStudyRegistryConverter::sisuAttainmentToStudyAttainment)
@@ -78,7 +77,7 @@ public class SisuStudyRegistry implements StudyRegistry {
 
     @Override
     public List<StudyAttainment> getStudyAttainments(String personId, String studentNumber) {
-        return getStudyAttainments(IntegrationUtil.getSisuPrivatePersonId(personId));
+        return getStudyAttainments(personId);
     }
 
     @Override
@@ -98,6 +97,6 @@ public class SisuStudyRegistry implements StudyRegistry {
 
     @Override
     public Person getPerson(String personId) {
-        return sisuStudyRegistryConverter.sisuPrivatePersonToPerson(sisuClient.getPrivatePerson(IntegrationUtil.getSisuPrivatePersonId(personId)));
+        return sisuStudyRegistryConverter.sisuPrivatePersonToPerson(sisuClient.getPrivatePerson(personId));
     }
 }

--- a/src/main/java/fi/helsinki/opintoni/integration/studyregistry/sisu/mock/SisuMockClient.java
+++ b/src/main/java/fi/helsinki/opintoni/integration/studyregistry/sisu/mock/SisuMockClient.java
@@ -138,7 +138,7 @@ public class SisuMockClient implements SisuClient {
         PrivatePersonTO pp = new PrivatePersonTO();
         pp.setStudentNumber("010189791");
         pp.setEmployeeNumber("010540");
-        r.setData(Map.of(personId, pp));
+        r.setData(Map.of("private_person", pp));
         return r;
     }
 
@@ -146,6 +146,7 @@ public class SisuMockClient implements SisuClient {
     public Private_personQueryResponse getStudyAttainments(String personId) {
         AttainmentTO attainment = new AttainmentTO();
         attainment.setId("hy-opinto-126377006");
+        attainment.setGradeId("3");
         attainment.setCredits(5.0);
         attainment.setAttainmentDate("2019-05-09");
         attainment.setGradeScale(getGradeScale());
@@ -153,7 +154,7 @@ public class SisuMockClient implements SisuClient {
         PrivatePersonTO pp = new PrivatePersonTO();
         pp.setAttainments(List.of(attainment));
         Private_personQueryResponse r = new Private_personQueryResponse();
-        r.setData(Map.of(personId, pp));
+        r.setData(Map.of("private_person", pp));
         return r;
     }
 

--- a/src/main/java/fi/helsinki/opintoni/security/AppUser.java
+++ b/src/main/java/fi/helsinki/opintoni/security/AppUser.java
@@ -27,8 +27,6 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 
-import fi.helsinki.opintoni.integration.IntegrationUtil;
-
 import java.security.Principal;
 import java.util.Collection;
 import java.util.Collections;
@@ -85,10 +83,6 @@ public final class AppUser extends User {
 
     public String getPersonId() {
         return personId;
-    }
-
-    public String getSisuPersonId() {
-        return IntegrationUtil.getSisuPrivatePersonId(getPersonId());
     }
 
     public String getEduPersonPrincipalName() {

--- a/src/main/java/fi/helsinki/opintoni/security/DevUserDetailsService.java
+++ b/src/main/java/fi/helsinki/opintoni/security/DevUserDetailsService.java
@@ -79,7 +79,7 @@ public class DevUserDetailsService implements org.springframework.security.core.
             .email("opettaja@mail.helsinki.fi")
             .commonName("Olli Opettaja")
             .employeeNumber("010540")
-            .personId("1000")
+            .personId("hy-hlo-1000")
             .role(AppUser.Role.ADMIN)
             .build();
     }
@@ -90,7 +90,7 @@ public class DevUserDetailsService implements org.springframework.security.core.
             .email("opiskelija@mail.helsinki.fi")
             .commonName("Olli Opiskelija")
             .studentNumber("010189791")
-            .personId("1001")
+            .personId("hy-hlo-1001")
             .build();
     }
 
@@ -100,7 +100,7 @@ public class DevUserDetailsService implements org.springframework.security.core.
             .email("opiskelija@mail.helsinki.fi")
             .commonName("Maggie Simpson")
             .studentNumber("011631484")
-            .personId("80")
+            .personId("hy-hlo-80")
             .build();
     }
 
@@ -112,7 +112,7 @@ public class DevUserDetailsService implements org.springframework.security.core.
             .commonName("Hybrid User")
             .employeeNumber("010540")
             .studentNumber("010189791")
-            .personId("1002")
+            .personId("hy-hlo-1002")
             .build();
     }
 
@@ -123,7 +123,7 @@ public class DevUserDetailsService implements org.springframework.security.core.
             .email("testteacher@mail.helsinki.fi")
             .commonName("Test Teacher")
             .employeeNumber("010540")
-            .personId("1003")
+            .personId("hy-hlo-1003")
             .build();
     }
 
@@ -133,7 +133,7 @@ public class DevUserDetailsService implements org.springframework.security.core.
             .email("teststudent@mail.helsinki.fi")
             .commonName("Test Student")
             .studentNumber("010189791")
-            .personId("1004")
+            .personId("hy-hlo-1004")
             .build();
     }
 
@@ -145,7 +145,7 @@ public class DevUserDetailsService implements org.springframework.security.core.
             .commonName("Test Hybrid User")
             .employeeNumber("010540")
             .studentNumber("010189791")
-            .personId("1005")
+            .personId("hy-hlo-1005")
             .build();
     }
 
@@ -155,7 +155,7 @@ public class DevUserDetailsService implements org.springframework.security.core.
             .email("testopenunistudent@mail.helsinki.fi")
             .commonName("Test Open Uni Student")
             .studentNumber(STUDENT_NUMBER_TEST_OPEN_UNI_STUDENT)
-            .personId("1006")
+            .personId("hy-hlo-1006")
             .build();
     }
 
@@ -165,7 +165,7 @@ public class DevUserDetailsService implements org.springframework.security.core.
             .email("testnewstudent@mail.helsinki.fi")
             .commonName("Test New Student")
             .studentNumber(STUDENT_NUMBER_TEST_NEW_STUDENT)
-            .personId("1007")
+            .personId("hy-hlo-1007")
             .build();
     }
 }

--- a/src/main/java/fi/helsinki/opintoni/security/SAMLUserDetailsService.java
+++ b/src/main/java/fi/helsinki/opintoni/security/SAMLUserDetailsService.java
@@ -42,7 +42,7 @@ public class SAMLUserDetailsService implements org.springframework.security.saml
     private static final String SAML_ATTRIBUTE_EDU_PERSON_PRINCIPAL_NAME = "urn:oid:1.3.6.1.4.1.5923.1.1.1.6";
     private static final String SAML_ATTRIBUTE_EMAIL = "urn:oid:0.9.2342.19200300.100.1.3";
     private static final String SAML_ATTRIBUTE_COMMON_NAME = "urn:oid:2.5.4.3";
-    private static final String SAML_ATTRIBUTE_OODI_UID = "1.3.6.1.4.1.18869.1.1.1.32";
+    private static final String SAML_ATTRIBUTE_PERSON_SISU_ID = "urn:oid:1.3.6.1.4.1.18869.1.1.1.48";
     private static final String SAML_ATTRIBUTE_EMPLOYEE_NUMBER = "urn:oid:2.16.840.1.113730.3.1.3";
     private static final String SAML_ATTRIBUTE_STUDENT_NUMBER = "urn:oid:1.3.6.1.4.1.25178.1.2.14";
     private static final String SAML_ATTRIBUTE_TEACHER_FACULTY_CODE = "urn:mace:funet.fi:helsinki.fi:hyAccountingCode";
@@ -67,7 +67,7 @@ public class SAMLUserDetailsService implements org.springframework.security.saml
             .eduPersonPrincipalName(credential.getAttributeAsString(SAML_ATTRIBUTE_EDU_PERSON_PRINCIPAL_NAME))
             .email(credential.getAttributeAsString(SAML_ATTRIBUTE_EMAIL))
             .commonName(credential.getAttributeAsString(SAML_ATTRIBUTE_COMMON_NAME))
-            .personId(credential.getAttributeAsString(SAML_ATTRIBUTE_OODI_UID))
+            .personId(credential.getAttributeAsString(SAML_ATTRIBUTE_PERSON_SISU_ID))
             .studentNumber(getStudentNumber(credential))
             .employeeNumber(credential.getAttributeAsString(SAML_ATTRIBUTE_EMPLOYEE_NUMBER))
             .teacherFacultyCode(credential.getAttributeAsString(SAML_ATTRIBUTE_TEACHER_FACULTY_CODE))

--- a/src/main/java/fi/helsinki/opintoni/security/SecurityUtils.java
+++ b/src/main/java/fi/helsinki/opintoni/security/SecurityUtils.java
@@ -17,8 +17,6 @@
 
 package fi.helsinki.opintoni.security;
 
-import fi.helsinki.opintoni.config.AppConfiguration;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
@@ -33,15 +31,8 @@ import java.util.stream.Collectors;
 @Component
 public class SecurityUtils {
 
-    private final AppConfiguration appConfiguration;
-
     @Value("#{'${whitelistedIps:127.0.0.1}'.split(',')}")
     private List<String> whitelistedIps;
-
-    @Autowired
-    public SecurityUtils(AppConfiguration appConfiguration) {
-        this.appConfiguration = appConfiguration;
-    }
 
     public String getCurrentLogin() {
         SecurityContext securityContext = SecurityContextHolder.getContext();

--- a/src/main/java/fi/helsinki/opintoni/service/OpenUniversityService.java
+++ b/src/main/java/fi/helsinki/opintoni/service/OpenUniversityService.java
@@ -34,7 +34,7 @@ public class OpenUniversityService {
     @SuppressWarnings("squid:S3655") // User having either employee number and/or student number is guaranteed in appUser instance creation
     public boolean isOpenUniversityUser(AppUser appUser) {
         if (appUser.isTeacher()) {
-            return userRoleService.isOpenUniversityTeacher(appUser.getSisuPersonId());
+            return userRoleService.isOpenUniversityTeacher(appUser.getPersonId());
         } else {
             return userRoleService.isOpenUniversityStudent(appUser.getStudentNumber().get());
         }

--- a/src/main/java/fi/helsinki/opintoni/service/usefullink/TeacherDefaultUsefulLinksService.java
+++ b/src/main/java/fi/helsinki/opintoni/service/usefullink/TeacherDefaultUsefulLinksService.java
@@ -53,8 +53,7 @@ public class TeacherDefaultUsefulLinksService extends DefaultUsefulLinksService 
     }
 
     public void createDefaultLinks(User user, AppUser appUser) {
-        boolean isOu = userRoleService.isOpenUniversityTeacher(appUser.getSisuPersonId());
-        List<UsefulLink> usefulLinks = userRoleService.isOpenUniversityTeacher(appUser.getSisuPersonId())
+        List<UsefulLink> usefulLinks = userRoleService.isOpenUniversityTeacher(appUser.getPersonId())
             ? createLocalizedUsefulLinks(openUniversityDefaultUsefulLinks, user)
             : createUsefulLinksForTeacher(user, appUser);
 

--- a/src/main/java/fi/helsinki/opintoni/web/arguments/UsernameArgumentResolver.java
+++ b/src/main/java/fi/helsinki/opintoni/web/arguments/UsernameArgumentResolver.java
@@ -20,7 +20,6 @@ package fi.helsinki.opintoni.web.arguments;
 import fi.helsinki.opintoni.exception.http.ForbiddenException;
 import fi.helsinki.opintoni.security.AppUser;
 import fi.helsinki.opintoni.security.SecurityUtils;
-import fi.helsinki.opintoni.service.UserService;
 import org.springframework.core.MethodParameter;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -31,11 +30,9 @@ import static fi.helsinki.opintoni.exception.http.ForbiddenException.forbiddenEx
 
 public class UsernameArgumentResolver implements HandlerMethodArgumentResolver {
 
-    private final UserService userService;
     private final SecurityUtils securityUtils;
 
-    public UsernameArgumentResolver(UserService userService, SecurityUtils securityUtils) {
-        this.userService = userService;
+    public UsernameArgumentResolver(SecurityUtils securityUtils) {
         this.securityUtils = securityUtils;
     }
 
@@ -57,7 +54,7 @@ public class UsernameArgumentResolver implements HandlerMethodArgumentResolver {
         MethodParameter parameter,
         ModelAndViewContainer mavContainer,
         NativeWebRequest webRequest,
-        WebDataBinderFactory binderFactory) throws Exception {
+        WebDataBinderFactory binderFactory) {
 
         return securityUtils.getAppUser()
             .map(AppUser::getEduPersonPrincipalName)

--- a/src/main/java/fi/helsinki/opintoni/web/rest/privateapi/EnrollmentResource.java
+++ b/src/main/java/fi/helsinki/opintoni/web/rest/privateapi/EnrollmentResource.java
@@ -57,14 +57,14 @@ public class EnrollmentResource extends AbstractResource {
     @RequestMapping(value = "/teachers/enrollments/events", method = RequestMethod.GET)
     @Timed
     public ResponseEntity<List<EventDto>> getTeacherEvents(Principal principal, Locale locale) {
-        return response(eventService.getTeacherEvents(AppUser.appUser(principal).getSisuPersonId(), locale));
+        return response(eventService.getTeacherEvents(AppUser.appUser(principal).getPersonId(), locale));
     }
 
     @TeacherRoleRequired
     @RequestMapping(value = "/teachers/enrollments/courses", method = RequestMethod.GET)
     @Timed
     public ResponseEntity<List<CourseDto>> getTeacherCourses(Principal principal, Locale locale) {
-        return response(courseService.getTeacherCourses(AppUser.appUser(principal).getSisuPersonId(), locale));
+        return response(courseService.getTeacherCourses(AppUser.appUser(principal).getPersonId(), locale));
     }
 
 }

--- a/src/main/java/fi/helsinki/opintoni/web/rest/privateapi/profile/PrivateProfileResource.java
+++ b/src/main/java/fi/helsinki/opintoni/web/rest/privateapi/profile/PrivateProfileResource.java
@@ -53,7 +53,6 @@ import java.util.Locale;
 public class PrivateProfileResource extends AbstractResource {
     private final ProfileService profileService;
     private final EmployeeProfileService employeeProfileService;
-    private final UserSettingsService userSettingsService;
 
     @Autowired
     public PrivateProfileResource(ProfileService profileService,
@@ -61,7 +60,6 @@ public class PrivateProfileResource extends AbstractResource {
                                   UserSettingsService userSettingsService) {
         this.profileService = profileService;
         this.employeeProfileService = employeeProfileService;
-        this.userSettingsService = userSettingsService;
     }
 
     @RequestMapping(value = "/{profileRole}", method = RequestMethod.GET)

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -474,7 +474,7 @@ obar:
     jwtTimeout: 60 # seconds
 
 studyregistry:
-    oodiDatasets:
+    sisuDatasets:
         - STUDENT_ENROLLMENTS
         - STUDENT_EVENTS
         - STUDY_RIGHTS

--- a/src/main/resources/config/liquibase/changelog/initial_schema.xml
+++ b/src/main/resources/config/liquibase/changelog/initial_schema.xml
@@ -2200,4 +2200,12 @@
             ]]>
         </sql>
     </changeSet>
+
+    <changeSet id="OO-1510" author="TH">
+        <sql splitStatements="false">
+            <![CDATA[
+            update user_account set person_id = concat('hy-hlo-', person_id)
+            ]]>
+        </sql>
+    </changeSet>
 </databaseChangeLog>

--- a/src/test/java/fi/helsinki/opintoni/security/SAMLUserDetailsServiceTest.java
+++ b/src/test/java/fi/helsinki/opintoni/security/SAMLUserDetailsServiceTest.java
@@ -36,7 +36,7 @@ public class SAMLUserDetailsServiceTest {
         ".org:schac:personalUniqueCode:int:studentID:helsinki.fi:011631484";
     private static final String SAML_STUDENT_NUMBER_FINAL = "011631484";
     private static final String SAML_EMPLOYEE_NUMBER = "employeeNumber";
-    private static final String OODI_PERSON_ID = "1440748";
+    private static final String SISU_PERSON_ID = "hy-hlo-1440748";
     private static final String SAML_PREFERRED_LANGUAGE = "fi";
 
     private final UserService userService = mock(UserService.class);
@@ -52,7 +52,7 @@ public class SAMLUserDetailsServiceTest {
         assertThat(appUser.getUsername()).isEqualTo(SAML_PRINCIPAL_NAME);
         assertThat(appUser.getEmail()).isEqualTo(SAML_EMAIL);
         assertThat(appUser.getCommonName()).isEqualTo(SAML_COMMON_NAME);
-        assertThat(appUser.getPersonId()).isEqualTo(OODI_PERSON_ID);
+        assertThat(appUser.getPersonId()).isEqualTo(SISU_PERSON_ID);
         assertThat(appUser.getStudentNumber().get()).isEqualTo(SAML_STUDENT_NUMBER_FINAL);
         assertThat(appUser.getPreferredLanguage()).isEqualTo(SAML_PREFERRED_LANGUAGE);
         assertThat(appUser.getEmployeeNumber().isPresent()).isFalse();
@@ -71,7 +71,7 @@ public class SAMLUserDetailsServiceTest {
         assertThat(appUser.getUsername()).isEqualTo(SAML_PRINCIPAL_NAME);
         assertThat(appUser.getEmail()).isEqualTo(SAML_EMAIL);
         assertThat(appUser.getCommonName()).isEqualTo(SAML_COMMON_NAME);
-        assertThat(appUser.getPersonId()).isEqualTo(OODI_PERSON_ID);
+        assertThat(appUser.getPersonId()).isEqualTo(SISU_PERSON_ID);
         assertThat(appUser.getEmployeeNumber().get()).isEqualTo(SAML_EMPLOYEE_NUMBER);
         assertThat(appUser.getPreferredLanguage()).isEqualTo(SAML_PREFERRED_LANGUAGE);
         assertThat(appUser.getStudentNumber().isPresent()).isFalse();
@@ -141,7 +141,7 @@ public class SAMLUserDetailsServiceTest {
         when(credential.getAttributeAsString("urn:oid:1.3.6.1.4.1.5923.1.1.1.6")).thenReturn(SAML_PRINCIPAL_NAME);
         when(credential.getAttributeAsString("urn:oid:0.9.2342.19200300.100.1.3")).thenReturn(SAML_EMAIL);
         when(credential.getAttributeAsString("urn:oid:2.5.4.3")).thenReturn(SAML_COMMON_NAME);
-        when(credential.getAttributeAsString("1.3.6.1.4.1.18869.1.1.1.32")).thenReturn(OODI_PERSON_ID);
+        when(credential.getAttributeAsString("urn:oid:1.3.6.1.4.1.18869.1.1.1.48")).thenReturn(SISU_PERSON_ID);
         when(credential.getAttributeAsString("urn:oid:2.16.840.1.113730.3.1.39")).thenReturn(SAML_PREFERRED_LANGUAGE);
         return credential;
     }

--- a/src/test/java/fi/helsinki/opintoni/web/arguments/UsernameArgumentResolverTest.java
+++ b/src/test/java/fi/helsinki/opintoni/web/arguments/UsernameArgumentResolverTest.java
@@ -41,7 +41,7 @@ public class UsernameArgumentResolverTest  extends SpringTest {
 
     @Before
     public void setUp() {
-        resolver = new UsernameArgumentResolver(userService, securityUtils);
+        resolver = new UsernameArgumentResolver(securityUtils);
     }
 
     @Test


### PR DESCRIPTION
- A DB migration adds a 'hy-hlo' prefix to all user_account.person_id values.
- Now using Shibboleth attribute hyPersonSisuId instead of OodiUid for identification of the user.
- No longer passing user ID to Obar, as it does not use it.

https://jira.it.helsinki.fi/browse/OO-1511 Konfiguroidaan Profiili hakemaan tiedot Sisusta Oodin sijaan
- Configured all data sets to be fetched from Sisu instead of Oodi.
- Fixed problems in SisuMockClient. How Did This Ever Work?™

https://jira.it.helsinki.fi/browse/OO-1502 New Relic -virhe opettajan kalenterifiidiin liittyen
- List.of() returns an immutable list, so using Lists.newArrayList() instead.

Househoulding:
- Changed misleading variable names, such as teacherNumber that was actually holding a personId.
- Removed unused variables.