### PR TITLE
https://jira.it.helsinki.fi/browse/OO-1510 OodiUid -> hyPersonSisuId

### DIFF
--- a/src/main/java/fi/helsinki/opintoni/integration/studyregistry/oodi/OodiStudyRegistry.java
+++ b/src/main/java/fi/helsinki/opintoni/integration/studyregistry/oodi/OodiStudyRegistry.java
@@ -111,9 +111,22 @@ public class OodiStudyRegistry implements StudyRegistry {
             .oodiCourseUnitRealisationTeachersToTeachers(oodiClient.getCourseUnitRealisationTeachers(realisationId));
     }
 
+    // Only works with persons migrated from Oodi, as their IDs start with the known prefix.
+    // Profile must and will be switched to integrate to Sisu instead of Oodi before
+    // Sisu native persons appear.
+    private String toOodiId(String personId) {
+        String sisuPrefix = "hy-hlo-";
+        if (personId.startsWith(sisuPrefix)) {
+            personId = personId.replace(sisuPrefix, "");
+        }
+        // Check that we have an integer:
+        Long.valueOf(personId);
+        return personId;
+    }
+
     @Override
     public Person getPerson(String personId) {
-        OodiRoles oodiRoles = oodiClient.getRoles(personId);
+        OodiRoles oodiRoles = oodiClient.getRoles(toOodiId(personId));
 
         return oodiStudyRegistryConverter.oodiRolesToPerson(oodiRoles);
     }

--- a/src/test/java/fi/helsinki/opintoni/integration/studyregistry/StudyRegistryServiceCacheTest.java
+++ b/src/test/java/fi/helsinki/opintoni/integration/studyregistry/StudyRegistryServiceCacheTest.java
@@ -115,4 +115,23 @@ public class StudyRegistryServiceCacheTest extends SpringTest {
 
         assertThat(studyRights).isSameAs(cachedStudyRights);
     }
+
+    @Test
+    public void thatPersonIdIsTransformedToOodiFormatWhenFetchingStudyAttainments() {
+        studentRequestChain(STUDENT_NUMBER).roles("1234").attainments();
+
+        studyRegistryService.getStudyAttainments("hy-hlo-1234");
+    }
+
+    @Test
+    public void thatOodiPersonIdStillWorksForFetchingStudyAttainments() {
+        studentRequestChain(STUDENT_NUMBER).roles("1234").attainments();
+
+        studyRegistryService.getStudyAttainments("1234");
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void thatSisuNativePersonIdThrowsExceptionWhenFetchingStudyAttainments() {
+        studyRegistryService.getStudyAttainments("otm-sisu-native-id-here");
+    }
 }

--- a/src/test/java/fi/helsinki/opintoni/web/requestchain/StudentRequestChain.java
+++ b/src/test/java/fi/helsinki/opintoni/web/requestchain/StudentRequestChain.java
@@ -96,8 +96,8 @@ public class StudentRequestChain {
         return this;
     }
 
-    public StudentRequestChain roles(String responseFile) {
-        oodiServer.expectRolesRequest(TestConstants.STUDENT_PERSON_ID, responseFile);
+    public StudentRequestChain roles(String personId) {
+        oodiServer.expectRolesRequest(personId);
         return this;
     }
 


### PR DESCRIPTION
- Fixed failing study attainment calls in Profile: As Profile still integrates with Oodi, we need to transform the Sisu personId into Oodi PersonId on the fly, where it is used in Oodi calls.