### PR TITLE
OO-1513 bintray sunsetting, remove unnecessary amex repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,6 @@ if(hasProperty("opintoni_artifactory_base_url")) {
     }
 } else {
     repositories {
-        maven { url 'https://dl.bintray.com/americanexpress/maven/' }
         mavenLocal()
         jcenter()
     }


### PR DESCRIPTION
OO backend ei käytä amex maven repossa olevaa graphql kirjastoa. Amex maven repo on bintrayssä, mikä muutenkin lopetetaan 1.5.2021. Kyseinen maven repo on poistettu `build.gradle` -tiedostosta.