### PR TITLE
OO-1519 schacPersonalUniqueCode attribute filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ local Opintoni header is used (for instance when running e2e tests). When using 
 
 `./gradlew bootRun ----debug-jvm`
 
+### Running with local shibboleth authentication
+
+[Instructions for running local shibboleth authentication](src/main/local-shibbo/README.md)
+
 ### Running tests
 
 `./gradlew test`

--- a/src/main/java/fi/helsinki/opintoni/security/SAMLUserDetailsService.java
+++ b/src/main/java/fi/helsinki/opintoni/security/SAMLUserDetailsService.java
@@ -50,7 +50,7 @@ public class SAMLUserDetailsService implements org.springframework.security.saml
     private static final String SAML_ATTRIBUTE_STUDENT_NUMBER = "urn:oid:1.3.6.1.4.1.25178.1.2.14";
     private static final String SAML_ATTRIBUTE_TEACHER_FACULTY_CODE = "urn:mace:funet.fi:helsinki.fi:hyAccountingCode";
     private static final String SAML_ATTRIBUTE_PREFERRED_LANGUAGE = "urn:oid:2.16.840.1.113730.3.1.39";
-    private static final String PERSONAL_UNIQUE_CODE_HY_STUDENT_ID_PREFIX = "schac:personalUniqueCode:int:studentID:helsinki.fi:";
+    private static final String PERSONAL_UNIQUE_CODE_UH_STUDENT_ID_PREFIX = "schac:personalUniqueCode:int:studentID:helsinki.fi:";
 
     private final UserService userService;
 
@@ -102,7 +102,7 @@ public class SAMLUserDetailsService implements org.springframework.security.saml
      * Get student number from multiple directory strings, possible values are as follows
      * Valid student personalUniqueCodes:
      * "urn:schac:personalUniqueCode:int:studentID:helsinki.fi:011631484"
-     * Valid personalUniqueCodes, but not invalid for University of Helsinki, filter out:
+     * Valid personalUniqueCodes, but invalid student IDs for University of Helsinki, filter out:
      * "urn:schac:personalUniqueCode:int:studentID:tut.fi:011631484"
      * "urn:schac:personalUniqueCode:se:LIN:87654321"
      */
@@ -111,7 +111,7 @@ public class SAMLUserDetailsService implements org.springframework.security.saml
         String[] schacPersonalUniqueCodes = credential.getAttributeAsStringArray(SAML_ATTRIBUTE_STUDENT_NUMBER);
         if (schacPersonalUniqueCodes != null) {
             studentNumber = Arrays.asList(schacPersonalUniqueCodes).stream()
-                .filter(code -> code.contains(PERSONAL_UNIQUE_CODE_HY_STUDENT_ID_PREFIX))
+                .filter(code -> code.contains(PERSONAL_UNIQUE_CODE_UH_STUDENT_ID_PREFIX))
                 .map(code -> StringUtils.substringAfterLast(code, ":"))
                 .findAny()
                 .orElse(null);

--- a/src/test/java/fi/helsinki/opintoni/security/SAMLUserDetailsServiceTest.java
+++ b/src/test/java/fi/helsinki/opintoni/security/SAMLUserDetailsServiceTest.java
@@ -68,7 +68,7 @@ public class SAMLUserDetailsServiceTest {
     }
 
     @Test
-    public void thatStudentAppUserWithMultipleUniversityStudentIDsReturnedWithUHStudentNumber() {
+    public void thatStudentAppUserWithMultipleUniversityStudentIDsIsReturnedWithUHStudentNumber() {
         SAMLCredential credential = samlStudentWithMultipleUniversityStudentIdsCredential();
 
         AppUser appUser = (AppUser) userDetailsService.loadUserBySAML(credential);

--- a/src/test/java/fi/helsinki/opintoni/security/SAMLUserDetailsServiceTest.java
+++ b/src/test/java/fi/helsinki/opintoni/security/SAMLUserDetailsServiceTest.java
@@ -29,15 +29,16 @@ import static org.mockito.Mockito.when;
 
 public class SAMLUserDetailsServiceTest {
 
+    private static final String SAML_PERSONAL_UNIQUE_CODE_FIELD = "urn:oid:1.3.6.1.4.1.25178.1.2.14";
     private static final String SAML_EMAIL = "email";
     private static final String SAML_COMMON_NAME = "commonName";
     private static final String SAML_PRINCIPAL_NAME = "eduPersonPrincipalName";
-    private static final String SAML_STUDENT_NUMBER = "urn:mace:terena" +
-        ".org:schac:personalUniqueCode:int:studentID:helsinki.fi:011631484";
-    private static final String SAML_OTHER_UNIVERSITY_STUDENT_NUMBER = "urn:mace:terena" +
-        ".org:schac:personalUniqueCode:int:studentID:tut.fi:011631484";
-    private static final String SAML_EMPLOYEE_PERSONAL_UNIQUE_CODE = "urn:mace:terena"
-            + ".org:schac:personalUniqueCode:se:LIN:112435";
+    private static final String SAML_STUDENT_NUMBER =
+        "urn:schac:personalUniqueCode:int:studentID:helsinki.fi:011631484";
+    private static final String SAML_OTHER_UNIVERSITY_STUDENT_NUMBER =
+        "urn:schac:personalUniqueCode:int:studentID:tut.fi:011631484";
+    private static final String SAML_EMPLOYEE_PERSONAL_UNIQUE_CODE =
+        "urn:schac:personalUniqueCode:se:LIN:112435";
     private static final String SAML_STUDENT_NUMBER_FINAL = "011631484";
     private static final String SAML_EMPLOYEE_NUMBER = "employeeNumber";
     private static final String SISU_PERSON_ID = "hy-hlo-1440748";
@@ -67,8 +68,8 @@ public class SAMLUserDetailsServiceTest {
     }
 
     @Test
-    public void thatStudentAppUserWithMultipleUniversityStudentIDIsReturnedWithCorrectStudentNumber() {
-        SAMLCredential credential = samlStudentOtherUniversityCredential();
+    public void thatStudentAppUserWithMultipleUniversityStudentIDsReturnedWithUHStudentNumber() {
+        SAMLCredential credential = samlStudentWithMultipleUniversityStudentIdsCredential();
 
         AppUser appUser = (AppUser) userDetailsService.loadUserBySAML(credential);
         assertThat(appUser.getStudentNumber().get()).isEqualTo(SAML_STUDENT_NUMBER_FINAL);
@@ -139,7 +140,7 @@ public class SAMLUserDetailsServiceTest {
     private SAMLCredential samlStudentCredential() {
         SAMLCredential credential = samlCommonCredential();
 
-        when(credential.getAttributeAsStringArray("urn:oid:1.3.6.1.4.1.25178.1.2.14")).thenReturn(new String[] {SAML_STUDENT_NUMBER});
+        when(credential.getAttributeAsStringArray(SAML_PERSONAL_UNIQUE_CODE_FIELD)).thenReturn(new String[] {SAML_STUDENT_NUMBER});
         return credential;
     }
 
@@ -152,7 +153,7 @@ public class SAMLUserDetailsServiceTest {
     private SAMLCredential samlHybridCredential() {
         SAMLCredential credential = samlCommonCredential();
         when(credential.getAttributeAsString("urn:oid:2.16.840.1.113730.3.1.3")).thenReturn(SAML_EMPLOYEE_NUMBER);
-        when(credential.getAttributeAsStringArray("urn:oid:1.3.6.1.4.1.25178.1.2.14")).thenReturn(new String[] {SAML_STUDENT_NUMBER});
+        when(credential.getAttributeAsStringArray(SAML_PERSONAL_UNIQUE_CODE_FIELD)).thenReturn(new String[] {SAML_STUDENT_NUMBER});
         return credential;
     }
 
@@ -166,10 +167,10 @@ public class SAMLUserDetailsServiceTest {
         return credential;
     }
 
-    private SAMLCredential samlStudentOtherUniversityCredential() {
+    private SAMLCredential samlStudentWithMultipleUniversityStudentIdsCredential() {
         SAMLCredential credential = samlCommonCredential();
 
-        when(credential.getAttributeAsStringArray("urn:oid:1.3.6.1.4.1.25178.1.2.14"))
+        when(credential.getAttributeAsStringArray(SAML_PERSONAL_UNIQUE_CODE_FIELD))
             .thenReturn(new String[] {SAML_OTHER_UNIVERSITY_STUDENT_NUMBER, SAML_STUDENT_NUMBER});
         return credential;
     }
@@ -177,7 +178,7 @@ public class SAMLUserDetailsServiceTest {
     private SAMLCredential samlNoValidStudentIDCredential() {
         SAMLCredential credential = samlCommonCredential();
 
-        when(credential.getAttributeAsStringArray("urn:oid:1.3.6.1.4.1.25178.1.2.14"))
+        when(credential.getAttributeAsStringArray(SAML_PERSONAL_UNIQUE_CODE_FIELD))
             .thenReturn(new String[] {SAML_EMPLOYEE_PERSONAL_UNIQUE_CODE, SAML_OTHER_UNIVERSITY_STUDENT_NUMBER});
         when(credential.getAttributeAsString("urn:oid:2.16.840.1.113730.3.1.3")).thenReturn(SAML_EMPLOYEE_NUMBER);
         return credential;

--- a/src/test/java/fi/helsinki/opintoni/security/SAMLUserDetailsServiceTest.java
+++ b/src/test/java/fi/helsinki/opintoni/security/SAMLUserDetailsServiceTest.java
@@ -34,6 +34,10 @@ public class SAMLUserDetailsServiceTest {
     private static final String SAML_PRINCIPAL_NAME = "eduPersonPrincipalName";
     private static final String SAML_STUDENT_NUMBER = "urn:mace:terena" +
         ".org:schac:personalUniqueCode:int:studentID:helsinki.fi:011631484";
+    private static final String SAML_OTHER_UNIVERSITY_STUDENT_NUMBER = "urn:mace:terena" +
+        ".org:schac:personalUniqueCode:int:studentID:tut.fi:011631484";
+    private static final String SAML_EMPLOYEE_PERSONAL_UNIQUE_CODE = "urn:mace:terena"
+            + ".org:schac:personalUniqueCode:se:LIN:112435";
     private static final String SAML_STUDENT_NUMBER_FINAL = "011631484";
     private static final String SAML_EMPLOYEE_NUMBER = "employeeNumber";
     private static final String SISU_PERSON_ID = "hy-hlo-1440748";
@@ -60,6 +64,22 @@ public class SAMLUserDetailsServiceTest {
 
         GrantedAuthority grantedAuthority = Iterables.getOnlyElement(appUser.getAuthorities());
         assertThat(grantedAuthority.getAuthority()).isEqualTo(AppUser.Role.STUDENT.name());
+    }
+
+    @Test
+    public void thatStudentAppUserWithMultipleUniversityStudentIDIsReturnedWithCorrectStudentNumber() {
+        SAMLCredential credential = samlStudentOtherUniversityCredential();
+
+        AppUser appUser = (AppUser) userDetailsService.loadUserBySAML(credential);
+        assertThat(appUser.getStudentNumber().get()).isEqualTo(SAML_STUDENT_NUMBER_FINAL);
+    }
+
+    @Test
+    public void thatStudentAppUserWithoutValidStudentIDIsReturnedWithoutStudentNumber() {
+        SAMLCredential credential = samlNoValidStudentIDCredential();
+
+        AppUser appUser = (AppUser) userDetailsService.loadUserBySAML(credential);
+        assertThat(appUser.getStudentNumber().isPresent()).isFalse();
     }
 
     @Test
@@ -119,7 +139,7 @@ public class SAMLUserDetailsServiceTest {
     private SAMLCredential samlStudentCredential() {
         SAMLCredential credential = samlCommonCredential();
 
-        when(credential.getAttributeAsString("urn:oid:1.3.6.1.4.1.25178.1.2.14")).thenReturn(SAML_STUDENT_NUMBER);
+        when(credential.getAttributeAsStringArray("urn:oid:1.3.6.1.4.1.25178.1.2.14")).thenReturn(new String[] {SAML_STUDENT_NUMBER});
         return credential;
     }
 
@@ -132,7 +152,7 @@ public class SAMLUserDetailsServiceTest {
     private SAMLCredential samlHybridCredential() {
         SAMLCredential credential = samlCommonCredential();
         when(credential.getAttributeAsString("urn:oid:2.16.840.1.113730.3.1.3")).thenReturn(SAML_EMPLOYEE_NUMBER);
-        when(credential.getAttributeAsString("urn:oid:1.3.6.1.4.1.25178.1.2.14")).thenReturn(SAML_STUDENT_NUMBER);
+        when(credential.getAttributeAsStringArray("urn:oid:1.3.6.1.4.1.25178.1.2.14")).thenReturn(new String[] {SAML_STUDENT_NUMBER});
         return credential;
     }
 
@@ -143,6 +163,23 @@ public class SAMLUserDetailsServiceTest {
         when(credential.getAttributeAsString("urn:oid:2.5.4.3")).thenReturn(SAML_COMMON_NAME);
         when(credential.getAttributeAsString("urn:oid:1.3.6.1.4.1.18869.1.1.1.48")).thenReturn(SISU_PERSON_ID);
         when(credential.getAttributeAsString("urn:oid:2.16.840.1.113730.3.1.39")).thenReturn(SAML_PREFERRED_LANGUAGE);
+        return credential;
+    }
+
+    private SAMLCredential samlStudentOtherUniversityCredential() {
+        SAMLCredential credential = samlCommonCredential();
+
+        when(credential.getAttributeAsStringArray("urn:oid:1.3.6.1.4.1.25178.1.2.14"))
+            .thenReturn(new String[] {SAML_OTHER_UNIVERSITY_STUDENT_NUMBER, SAML_STUDENT_NUMBER});
+        return credential;
+    }
+
+    private SAMLCredential samlNoValidStudentIDCredential() {
+        SAMLCredential credential = samlCommonCredential();
+
+        when(credential.getAttributeAsStringArray("urn:oid:1.3.6.1.4.1.25178.1.2.14"))
+            .thenReturn(new String[] {SAML_EMPLOYEE_PERSONAL_UNIQUE_CODE, SAML_OTHER_UNIVERSITY_STUDENT_NUMBER});
+        when(credential.getAttributeAsString("urn:oid:2.16.840.1.113730.3.1.3")).thenReturn(SAML_EMPLOYEE_NUMBER);
         return credential;
     }
 


### PR DESCRIPTION
Suodata pois ei-HY opiskelijanumerot `schacPersonalUniqueCode` -kentästä, valitse vain HY-opiskelijanumero.

Esimerkki: lista tunnuksia tulee `schacPersonalUniqueCode` kentässä:
  - `"urn:schac:personalUniqueCode:int:studentID:helsinki.fi:0000001"`
  - `"urn:schac:personalUniqueCode:int:studentID:tut.fi:011631484"`                                   
  - `"urn:schac:personalUniqueCode:se:LIN:87654321"`

Näistä `"urn:schac:personalUniqueCode:int:studentID:helsinki.fi:0000001"` on se mikä pitää valita, ja siitä ottaa vain viimeinen osa (`:` jälkeen), eli `0000001`.