### PR TITLE
https://jira.it.helsinki.fi/browse/OO-1522 esbmt1.it.helsinki.fi ajet…

### DIFF
--- a/src/main/java/fi/helsinki/opintoni/config/ESBConfiguration.java
+++ b/src/main/java/fi/helsinki/opintoni/config/ESBConfiguration.java
@@ -37,6 +37,7 @@ import static com.google.common.collect.Lists.newArrayList;
 public class ESBConfiguration {
     private static final String CLIENT_IMPLEMENTATION_PROPERTY = "esb.client.implementation";
     private static final String ESB_BASE_URL_PROPERTY = "esb.base.url";
+    private static final String ESB_APIKEY_PROPERTY = "esb.apiKey";
     private static final String REST_IMPLEMENTATION = "rest";
     private static final String MOCK_IMPLEMENTATION = "mock";
 
@@ -61,7 +62,7 @@ public class ESBConfiguration {
     }
 
     private ESBClient esbRestClient() {
-        return new ESBRestClient(appConfiguration.get(ESB_BASE_URL_PROPERTY), esbRestTemplate());
+        return new ESBRestClient(appConfiguration.get(ESB_BASE_URL_PROPERTY), appConfiguration.get(ESB_APIKEY_PROPERTY), esbRestTemplate());
     }
 
     private ESBClient esbMockClient() {

--- a/src/main/java/fi/helsinki/opintoni/integration/esb/ESBRestClient.java
+++ b/src/main/java/fi/helsinki/opintoni/integration/esb/ESBRestClient.java
@@ -21,7 +21,10 @@ import fi.helsinki.opintoni.integration.studyregistry.oodi.OodiRestClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.List;
@@ -33,11 +36,13 @@ public class ESBRestClient implements ESBClient {
 
     private static final Logger log = LoggerFactory.getLogger(OodiRestClient.class);
 
+    private String apiKey;
     private final RestTemplate restTemplate;
     private final String baseUrl;
 
-    public ESBRestClient(String baseUrl, RestTemplate restTemplate) {
+    public ESBRestClient(String baseUrl, String apiKey, RestTemplate restTemplate) {
         this.baseUrl = baseUrl;
+        this.apiKey = apiKey;
         this.restTemplate = restTemplate;
     }
 
@@ -45,9 +50,9 @@ public class ESBRestClient implements ESBClient {
     public List<ESBEmployeeInfo> getEmployeeInfo(String employeeNumber) {
         try {
             return restTemplate.exchange(
-                baseUrl + "/person/v2/employee/{employeeNumber}",
+                baseUrl + "/person/opetukseni/employee/{employeeNumber}",
                 HttpMethod.GET,
-                null,
+                apiKeyHeaders(),
                 new ParameterizedTypeReference<List<ESBEmployeeInfo>>() {
                 },
                 employeeNumber).getBody();
@@ -64,7 +69,7 @@ public class ESBRestClient implements ESBClient {
                 Optional.ofNullable(restTemplate.exchange(
                     baseUrl + "/optime/staff/{staffId}",
                     HttpMethod.GET,
-                    null,
+                    apiKeyHeaders(),
                     new ParameterizedTypeReference<OptimeStaffInformation>() {
                     },
                     staffId).getBody());
@@ -72,5 +77,11 @@ public class ESBRestClient implements ESBClient {
             log.error("Error when fetching Optime staff information info from ESB", e);
             return Optional.empty();
         }
+    }
+
+    private HttpEntity apiKeyHeaders() {
+        MultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
+        headers.add("Apikey", apiKey);
+        return new HttpEntity(headers);
     }
 }

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -174,7 +174,8 @@ adminAccounts: opettaja@helsinki.fi, opiskelija@helsinki.fi
 embedlyApiKey: dd741e653b0e4841bc59a60650031057
 
 esb:
-    base.url: https://esbmt2.it.helsinki.fi/devel
+    base.url: https://mock-esb.it.helsinki.fi/
+    apiKey: there is no api key for mock esb
     client.implementation: mock
 
 googleAnalyticsAccount:

--- a/src/test/java/fi/helsinki/opintoni/server/ESBServer.java
+++ b/src/test/java/fi/helsinki/opintoni/server/ESBServer.java
@@ -27,6 +27,7 @@ import org.springframework.web.client.RestTemplate;
 import static fi.helsinki.opintoni.service.profile.EmployeeContactInformationService.EMPLOYEE_NUMBER_PREFIX;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 public class ESBServer extends AbstractRestServiceServer {
@@ -41,10 +42,11 @@ public class ESBServer extends AbstractRestServiceServer {
     }
 
     public void expectEmployeeContactInformationRequest(String employeeNumber) {
-        server.expect(requestTo(String.format("%s/person/v2/employee/%s%s",
+        server.expect(requestTo(String.format("%s/person/opetukseni/employee/%s%s",
             baseUrl,
             EMPLOYEE_NUMBER_PREFIX,
             employeeNumber)))
+            .andExpect(header("Apikey", "abloy"))
             .andExpect(method(HttpMethod.GET))
             .andRespond(withSuccess(SampleDataFiles.toText("esb/employeeinfo.json"), MediaType.APPLICATION_JSON));
     }

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -153,7 +153,8 @@ optime:
     useOptimeFeedForWebCalendar: false
 
 esb:
-    base.url: https://esbmt2.it.helsinki.fi/devel
+    base.url: https://test-esb.helsinki.fi
+    apiKey: abloy
     client.implementation: rest
 
 iam:


### PR DESCRIPTION
…aan alas masterinvaihdon aikana

- Changed IAM URL from esbmt1 to esb-api.
- IAMRestClient now passes the configured api key in the HTTP header "Apikey".
- The employee endpoint has moved from /person/v2/employee/ to /person/opetukseni/employee/